### PR TITLE
Add Travis-CI build and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+os:
+  - linux
+
+matrix:
+  fast_finish: true


### PR DESCRIPTION
Hi,

This PR add Contious integration from travis-ci.
It tests stable, beta and nightly on linux.

It doesen't test on osx, because ive had some bad experiences adding osx to travis and the builds suddenly starting to take 3 hours.

fast_finish means that if other jobs fail it will mark the build completed immediately instead of waiting for it to finish.

I could also try to add appveyor ci if you would like me to.