### PR TITLE
Rename --target to --script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ libFuzzer is going to repeatedly call the `go()` function in the fuzzer script w
 `data` of length `size`, until your program hits an error condition (segfault, panic, etc). Write
 your `go()` function to hit the entry point you need.
 
-You can add more fuzz target scripts via `cargo fuzz --add name_of_script`. There
+You can add more fuzz scripts via `cargo fuzz --add name_of_script`. There
 is a `Cargo.toml` in the `fuzz/` folder where you can add dependencies.
 
 
-To fuzz a fuzz target, run:
+To fuzz a fuzz script, run:
 
 ```sh
 $ cd /path/to/project
-$ cargo fuzz --target fuzzer_script_1 # or whatever the target is named
+$ cargo fuzz --script fuzzer_script_1 # or whatever the script is named
 ```
 
 Then, wait till it finds something!

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,22 +19,22 @@ Cargo Fuzz
 
 Usage:
   cargo fuzz --init
-  cargo fuzz --target TARGET
-  cargo fuzz --add TARGET
+  cargo fuzz --script SCRIPT
+  cargo fuzz --add SCRIPT
   cargo fuzz (-h | --help)
 
 Options:
   -h --help         Show this screen.
   --init            Initialize fuzz folder
-  --target TARGET   Run with given fuzz target in fuzz/fuzzers
-  --add TARGET      Add a new fuzz target
+  --script SCRIPT   Run with given fuzz script in fuzz/fuzzers
+  --add SCRIPT      Add a new fuzz script
 ";
 
 #[derive(Debug, RustcDecodable)]
 struct Args {
     flag_init: bool,
     flag_add: Option<String>,
-    flag_target: Option<String>,
+    flag_script: Option<String>,
 }
 
 fn main() {
@@ -44,10 +44,10 @@ fn main() {
 
     let result = if args.flag_init {
         init_fuzz()
-    } else if let Some(target) = args.flag_add {
-        add_target(target)
-    } else if let Some(target) = args.flag_target {
-        let result = run_target(target);
+    } else if let Some(script) = args.flag_add {
+        add_script(script)
+    } else if let Some(script) = args.flag_script {
+        let result = run_script(script);
         if let Ok(success) = result {
             if success {
                 // Can this ever happen?
@@ -110,11 +110,11 @@ libfuzzer
 "#)?;
 
     let mut script = fs::File::create(path::Path::new("./fuzz/fuzzers/fuzzer_script_1.rs"))?;
-    dummy_target(&mut script)
+    dummy_script(&mut script)
 }
 
-/// Create a dummy fuzz target script at the given path
-fn dummy_target(script: &mut fs::File) -> io::Result<()> {
+/// Create a dummy fuzz script script at the given path
+fn dummy_script(script: &mut fs::File) -> io::Result<()> {
 write!(script, r#"
 #![no_main]
 extern crate fuzzer_sys;
@@ -126,20 +126,19 @@ pub extern fn go(data: *const u8, size: isize) -> i32 {{
 }}"#)
 }
 
-/// Add a new fuzz target script with a given name
-fn add_target(target: String) -> io::Result<()> {
-    let target_file = format!("fuzz/fuzzers/{}.rs", target);
-    let mut script = fs::File::create(path::Path::new(&target_file))?;
-    dummy_target(&mut script)?;
+/// Add a new fuzz script script with a given name
+fn add_script(script_name: String) -> io::Result<()> {
+    let script = format!("fuzz/fuzzers/{}.rs", script_name);
+    let mut script = fs::File::create(path::Path::new(&script))?;
+    dummy_script(&mut script)?;
 
     let mut cargo = fs::OpenOptions::new().append(true).open(path::Path::new("./fuzz/Cargo.toml"))?;
 
-write!(cargo, r#"
-[[bin]]
-name = "{0}"
-path = "fuzzers/{0}.rs"
-"#, target)
-
+    write!(cargo, r#"\
+    [[bin]]\
+    name = "{0}"\
+    path = "fuzzers/{0}.rs"\
+    "#, script_name)
 }
 
 /// Build or rebuild libFuzzer (rebuilds only if the compiler version changed)
@@ -176,15 +175,15 @@ fn rebuild_libfuzzer() -> io::Result<()> {
     env::set_current_dir("..")
 }
 
-/// Fuzz a given fuzz target
-fn run_target(target: String) -> io::Result<bool> {
+/// Fuzz a given fuzz script
+fn run_script(script: String) -> io::Result<bool> {
     env::set_current_dir("./fuzz")?;
     rebuild_libfuzzer()?;
     let mut cmd = process::Command::new("cargo");
     cmd.arg("rustc")
        .arg("--verbose")
        .arg("--bin")
-       .arg(&target)
+       .arg(&script)
        .arg("--")
        .arg("-L")
        .arg("libfuzzer/target/release")
@@ -193,11 +192,11 @@ fn run_target(target: String) -> io::Result<bool> {
 
     let result = cmd.spawn()?.wait()?;
     if !result.success() {
-        return Err(io::Error::new(io::ErrorKind::Other, "Failed to build fuzz target"))
+        return Err(io::Error::new(io::ErrorKind::Other, "Failed to build fuzz script"))
     }
 
     // can't use cargo run since we can't pass -L args to it
-    let path = format!("target/debug/{}", target);
+    let path = format!("target/debug/{}", script);
     let mut run_cmd = process::Command::new(path);
     let result = run_cmd.spawn()?.wait()?;
     Ok(result.success())


### PR DESCRIPTION
--target is a common flag for other `cargo` subcommands and may be confusing, so
rename it to --script instead. This also opens up ability to eventually use
--target the same way other cargo subcommands do (e.g. to cross-compile fuzzers?)

r? @Manishearth 