### PR TITLE
Move #![no_main] to the top to avoid confusion 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,8 +115,9 @@ libfuzzer
 
 /// Create a dummy fuzz target script at the given path
 fn dummy_target(script: &mut fs::File) -> io::Result<()> {
-write!(script, "{}", r#"
-#![no_main]
+write!(script, "{}", r#"#![no_main]
+
+
 extern crate fuzzer_sys;
 
 #[export_name="rust_fuzzer_test_input"]


### PR DESCRIPTION
It looks like an attribute on the extern crate. It isn't. If it's the first line
people will be less likely to stick extern crate decls above it.

(fixes #17)