### PR TITLE
Specify `publish = false` for generated crate.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,7 @@ write!(cargo, r#"
 name = "{0}-fuzz"
 version = "0.0.1"
 authors = ["Automatically generated"]
+publish = false
 
 [dependencies.{0}]
 path = ".."


### PR DESCRIPTION
Disclaimer: I haven't tested this

Presumably most users aren't going to want to publish their fuzzing crate