### PR TITLE
⚑⚐⚑⚐⚑⚐

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Simple wrapper around libFuzzer"
 repository = "https://github.com/rust-fuzz/cargo-fuzz/"
 
 [dependencies]
-docopt          = "0.7"
 rustc-serialize = "0.3"  # if you're using `derive(RustcDecodable)`
 cargo_metadata  = "0.1.2"
 term            = "0.4.5"
+clap            = "2.20.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
         ("run", matches) => exec_target(matches.expect("arguments present")),
         (s, _) => panic!("unimplemented subcommand {}!", s),
     }.map(|_| 0).unwrap_or_else(|err| {
-        writeln!(io::stderr(), "Error: {}", err).expect("failed writing to stderr");
+        utils::write_to_stderr(&format!("{}", err), None);
         1
     }));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,12 +17,12 @@ use std::io::Write;
 
 mod utils;
 
-const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
-
 fn main() {
     let app = App::new("cargo-fuzz")
-        .version(VERSION.unwrap_or("unknown"))
+        .version(option_env!("CARGO_PKG_VERSION").unwrap_or("0.0.0"))
+        .about(option_env!("CARGO_PKG_DESCRIPTION").unwrap_or(""))
         .setting(AppSettings::SubcommandRequired)
+        .setting(AppSettings::GlobalVersion)
         .subcommand(SubCommand::with_name("init").about("Initialize the fuzz folder"))
         .subcommand(SubCommand::with_name("run").about("Run the fuzz target in fuzz/fuzzers")
                     .arg(Arg::with_name("TARGET").required(true)))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,9 +2,10 @@ use std::io;
 use std::io::Write;
 use term;
 
+#[allow(dead_code)]
 pub fn print_message(msg: &str, color: term::color::Color) {
     let term_stdout = term::stdout();
-    
+
     if let Some(mut terminal) = term_stdout {
         let _ = terminal.fg(color);
         println!("{}", msg);
@@ -22,10 +23,9 @@ pub fn write_to_stderr(err_msg: &str, ext_msg: Option<&str>) {
         let _ = terminal.fg(term::color::RED);
         write!(io::stderr(), "Error: ")
             .expect("failed writing to stderr");
-        let _ = terminal.fg(term::color::WHITE);
+        let _ = terminal.reset();
         writeln!(io::stderr(), "{}", err_msg)
             .expect("failed writing to stderr");
-        let _ = terminal.reset();
     } else {
         write!(io::stderr(), "Error: ")
             .expect("failed writing to stderr");


### PR DESCRIPTION
Supersedes https://github.com/rust-fuzz/cargo-fuzz/pull/38
Fixes https://github.com/rust-fuzz/cargo-fuzz/issues/44
Fixes https://github.com/rust-fuzz/cargo-fuzz/issues/37
Fixes https://github.com/rust-fuzz/cargo-fuzz/issues/29
cc https://github.com/rust-fuzz/cargo-fuzz/issues/3 (allows passing arbitrary flags to invoked process)

This is what the CLI looks now:

```
$ cargo fuzz -h
cargo-fuzz 0.2.2
Simple wrapper around libFuzzer

USAGE:
    cargo-fuzz [dummy] [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:


SUBCOMMANDS:
    add     Add a new fuzz target
    help    Prints this message or the help of the given subcommand(s)
    init    Initialize the fuzz folder
    list    List all fuzz targets
    run     Run the fuzz target in fuzz/fuzzers


$ cargo fuzz run fuzzer_script_1 -- -help=1
Usage:

To run fuzzing pass 0 or more directories.
target/x86_64-unknown-linux-gnu/debug/fuzzer_script_1 [-flag1=val1 [-flag2=val2 ...] ] [dir1 [dir2 ...] ]

To run individual tests without fuzzing pass 1 or more files:
target/x86_64-unknown-linux-gnu/debug/fuzzer_script_1 [-flag1=val1 [-flag2=val2 ...] ] file1 [file2 ...]

Flags: (strictly in form -flag=value)
 verbosity                   	1	Verbosity level.
 seed                        	0	Random seed. If 0, seed is generated.
 runs                        	-1	Number of individual test runs (-1 for infinite runs).
...
```