### PR TITLE
Do not send email notifications for failed builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ os:
 
 matrix:
   fast_finish: true
+notifications:
+  email: false


### PR DESCRIPTION
Since the repo is now managed by bors and failures will not land(?) to master
these emails provide no benefit whatsoever.