### PR TITLE
An initial version of running cargo-fuzz within a docker container - need help :)!

### DIFF
--- a/etc/docker/.gitignore
+++ b/etc/docker/.gitignore
@@ -1,0 +1,1 @@
+docker-rust/

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -1,8 +1,4 @@
-FROM docker-rust
+FROM clux/muslrust:nightly
 MAINTAINER Sebastian Thiel "byronimo@gmail.com"
 
-RUN apt-get update && apt-get install -y --force-yes build-essential && \
-    apt-get remove --purge -y curl && apt-get autoclean && apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt cargo install --verbose cargo-fuzz
+RUN cargo install cargo-fuzz

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM docker-rust
+MAINTAINER Sebastian Thiel "byronimo@gmail.com"
+
+RUN apt-get update && apt-get install -y --force-yes build-essential libfuzzer-3.8-dev && \
+    apt-get remove --purge -y curl && apt-get autoclean && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt cargo install --verbose cargo-fuzz

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker-rust
 MAINTAINER Sebastian Thiel "byronimo@gmail.com"
 
-RUN apt-get update && apt-get install -y --force-yes build-essential libfuzzer-3.8-dev && \
+RUN apt-get update && apt-get install -y --force-yes build-essential && \
     apt-get remove --purge -y curl && apt-get autoclean && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/etc/docker/Makefile
+++ b/etc/docker/Makefile
@@ -5,9 +5,5 @@ info:
 	$(info --------------------------------------)
 	$(info build    | build the docker image)
 	
-docker-rust:
-	git clone https://github.com/octplane/docker-rust
-
-build: docker-rust
-	cd $< && docker build -t $< .
+build: 
 	docker build -t $(IMAGE_NAME) .

--- a/etc/docker/Makefile
+++ b/etc/docker/Makefile
@@ -1,0 +1,13 @@
+IMAGE_NAME=cargo-fuzz
+
+info:
+	$(info Available Targets)
+	$(info --------------------------------------)
+	$(info build    | build the docker image)
+	
+docker-rust:
+	git clone https://github.com/octplane/docker-rust
+
+build: docker-rust
+	cd $< && docker build -t $< .
+	docker build -t $(IMAGE_NAME) .


### PR DESCRIPTION
I am trying get `cargo-fuzz` to work for [`tokio-cassandra`](https://github.com/nhellwig/tokio-cassandra), and have to run it in docker to work on OSX.

The idea was to use an image based on `docker-rust` to get rust nightly, then install libfuzzer-3.8 and other requirements to run `cargo fuzz run ...` within a container.

However, it fails with a message indicating that main was not found, and I seem to be lacking the knowledge to trace this any further.

# Goals with this PR

* [x] Initial Dockerfiles which _could_ work
* [ ] Get tokio-cassandra fuzzed
* [ ] Help making fuzzing easy on OSX via Docker - at first by providing good instructions in the README file.

# How to reproduce

```
git clone https://github.com/nhellwig/tokio-cassandra
make -C tokio-cassandra fuzz
```

Which yields a lot of output.

<details>

```
git clone https://github.com/byron/cargo-fuzz .cargo-fuzz
Cloning into '.cargo-fuzz'...
/Library/Developer/CommandLineTools/usr/bin/make -C .cargo-fuzz/etc/docker build
git clone https://github.com/octplane/docker-rust
Cloning into 'docker-rust'...
cd docker-rust && docker build -t docker-rust .
Sending build context to Docker daemon 72.19 kB

Step 1/10 : FROM debian:stretch
 ---> 6f4d77d39d73
Step 2/10 : MAINTAINER Johannes Schickling "schickling.j@gmail.com"
 ---> Using cache
 ---> b8b6f984bcc1
Step 3/10 : ENV USER root
 ---> Using cache
 ---> 5528ea403351
Step 4/10 : ADD install.sh install.sh
 ---> Using cache
 ---> c92fed21dea1
Step 5/10 : RUN chmod +x install.sh
 ---> Using cache
 ---> 3dd0ccbe7fa7
Step 6/10 : RUN ./install.sh
 ---> Using cache
 ---> 655af521aa8f
Step 7/10 : RUN rm install.sh
 ---> Using cache
 ---> 6f6c3ee25a94
Step 8/10 : VOLUME /source
 ---> Using cache
 ---> 436ecf2a1d95
Step 9/10 : WORKDIR /source
 ---> Using cache
 ---> e8f62ffda4ed
Step 10/10 : CMD bash
 ---> Using cache
 ---> 1ab7bd76d5ec
Successfully built 1ab7bd76d5ec
docker build -t cargo-fuzz .
Sending build context to Docker daemon 75.78 kB

Step 1/4 : FROM docker-rust
 ---> 1ab7bd76d5ec
Step 2/4 : MAINTAINER Sebastian Thiel "byronimo@gmail.com"
 ---> Using cache
 ---> 21b430174574
Step 3/4 : RUN apt-get update && apt-get install -y --force-yes build-essential libfuzzer-3.8-dev &&     apt-get remove --purge -y curl && apt-get autoclean && apt-get clean &&     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ---> Using cache
 ---> 31260ebcee10
Step 4/4 : RUN SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt cargo install --verbose cargo-fuzz
 ---> Using cache
 ---> add8e3618362
Successfully built add8e3618362
docker run -v $PWD:/source cargo-fuzz cargo fuzz run decoder
    Updating git repository `https://github.com/rust-fuzz/libfuzzer-sys.git`
    Updating registry `https://github.com/rust-lang/crates.io-index`
    Updating git repository `https://github.com/tokio-rs/tokio-core`
 Downloading slab v0.3.0
 Downloading futures v0.1.10
 Downloading scoped-tls v0.1.0
 Downloading log v0.3.6
 Downloading mio v0.6.4
 Downloading net2 v0.2.26
 Downloading lazycell v0.4.0
 Downloading semver v0.6.0
 Downloading tokio-proto v0.1.0
 Downloading tokio-service v0.1.0
 Downloading error-chain v0.8.1
 Downloading byteorder v1.0.0
 Downloading quick-error v1.1.0
 Downloading semver-parser v0.7.0
 Downloading smallvec v0.2.1
 Downloading rand v0.3.15
 Downloading take v0.1.0
   Compiling lazycell v0.4.0
   Compiling semver-parser v0.7.0
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/lazycell-0.4.0/src/lib.rs --crate-name lazycell --crate-type lib -g -C metadata=be9e96c765fb82f1 -C extra-filename=-be9e96c765fb82f1 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/semver-parser-0.7.0/src/lib.rs --crate-name semver_parser --crate-type lib -g -C metadata=82acc3fab877e520 -C extra-filename=-82acc3fab877e520 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling log v0.3.6
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.3.6/src/lib.rs --crate-name log --crate-type lib -g --cfg feature=\"default\" --cfg feature=\"use_std\" -C metadata=b637bf0b0680ab8d -C extra-filename=-b637bf0b0680ab8d --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling futures v0.1.10
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.10/src/lib.rs --crate-name futures --crate-type lib -g --cfg feature=\"default\" --cfg feature=\"with-deprecated\" --cfg feature=\"use_std\" -C metadata=0b1038a4ee845431 -C extra-filename=-0b1038a4ee845431 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern log=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblog-b637bf0b0680ab8d.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling cfg-if v0.1.0
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/cfg-if-0.1.0/src/lib.rs --crate-name cfg_if --crate-type lib -g -C metadata=292f14b70981a79c -C extra-filename=-292f14b70981a79c --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling backtrace v0.3.0
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.0/build.rs --crate-name build_script_build --crate-type bin -g --cfg feature=\"libbacktrace\" --cfg feature=\"kernel32-sys\" --cfg feature=\"coresymbolication\" --cfg feature=\"libunwind\" --cfg feature=\"dbghelp\" --cfg feature=\"backtrace-sys\" --cfg feature=\"dbghelp-sys\" --cfg feature=\"dladdr\" --cfg feature=\"default\" --cfg feature=\"winapi\" -C metadata=4d922e79d0b3f0f4 --out-dir /source/./target/debug/build/backtrace-4d922e79d0b3f0f4 --emit=dep-info,link -L dependency=/source/./target/debug/deps --cap-lints allow`
   Compiling gcc v0.3.43
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.43/src/lib.rs --crate-name gcc --crate-type lib -g -C metadata=ef0306b64ab4cdb0 -C extra-filename=-ef0306b64ab4cdb0 --out-dir /source/./target/debug/deps --emit=dep-info,link -L dependency=/source/./target/debug/deps --cap-lints allow`
   Compiling tokio-service v0.1.0
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-service-0.1.0/src/lib.rs --crate-name tokio_service --crate-type lib -g -C metadata=007fbbb9d287c06e -C extra-filename=-007fbbb9d287c06e --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern futures=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libfutures-0b1038a4ee845431.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling scoped-tls v0.1.0
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/scoped-tls-0.1.0/src/lib.rs --crate-name scoped_tls --crate-type lib -g -C metadata=235529888121a3a7 -C extra-filename=-235529888121a3a7 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling semver v0.6.0
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/semver-0.6.0/src/lib.rs --crate-name semver --crate-type lib -g --cfg feature=\"default\" -C metadata=c35bfa6fa235102b -C extra-filename=-c35bfa6fa235102b --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern semver_parser=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libsemver_parser-82acc3fab877e520.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling take v0.1.0
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/take-0.1.0/src/lib.rs --crate-name take --crate-type lib -g -C metadata=3b273b5cdb86db9c -C extra-filename=-3b273b5cdb86db9c --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling smallvec v0.2.1
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/smallvec-0.2.1/lib.rs --crate-name smallvec --crate-type lib -g -C metadata=127fe4715298f2bd -C extra-filename=-127fe4715298f2bd --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling backtrace-sys v0.1.10
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-sys-0.1.10/build.rs --crate-name build_script_build --crate-type bin -g -C metadata=6f090e84bbeeafba --out-dir /source/./target/debug/build/backtrace-sys-6f090e84bbeeafba --emit=dep-info,link -L dependency=/source/./target/debug/deps --extern gcc=/source/./target/debug/deps/libgcc-ef0306b64ab4cdb0.rlib --cap-lints allow`
   Compiling winapi-build v0.1.1
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-build-0.1.1/src/lib.rs --crate-name build --crate-type lib -g -C metadata=62810576f9e98607 -C extra-filename=-62810576f9e98607 --out-dir /source/./target/debug/deps --emit=dep-info,link -L dependency=/source/./target/debug/deps --cap-lints allow`
   Compiling dbghelp-sys v0.2.0
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/dbghelp-sys-0.2.0/build.rs --crate-name build_script_build --crate-type bin -g -C metadata=63f6e37cae1a7d6b --out-dir /source/./target/debug/build/dbghelp-sys-63f6e37cae1a7d6b --emit=dep-info,link -L dependency=/source/./target/debug/deps --extern build=/source/./target/debug/deps/libbuild-62810576f9e98607.rlib --cap-lints allow`
   Compiling libfuzzer-sys v0.1.0 (https://github.com/rust-fuzz/libfuzzer-sys.git#9d00b47e)
     Running `rustc /root/.cargo/git/checkouts/libfuzzer-sys-e07fde05820d7bc6/9d00b47e0ef203543d304f2a969a3ced8817369c/src/lib.rs --crate-name libfuzzer_sys --crate-type lib -g -C metadata=30281862c9b2f740 -C extra-filename=-30281862c9b2f740 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
     Running `/source/./target/debug/build/backtrace-sys-6f090e84bbeeafba/build-script-build`
   Compiling winapi v0.2.8
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-0.2.8/src/lib.rs --crate-name winapi --crate-type lib -g -C metadata=497ae3b05d554b01 -C extra-filename=-497ae3b05d554b01 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling slab v0.3.0
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/slab-0.3.0/src/lib.rs --crate-name slab --crate-type lib -g -C metadata=5b6cda3fc92c5c7a -C extra-filename=-5b6cda3fc92c5c7a --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling libc v0.2.21
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.21/src/lib.rs --crate-name libc --crate-type lib -g --cfg feature=\"default\" --cfg feature=\"use_std\" -C metadata=b2b114c5e6d5dfb5 -C extra-filename=-b2b114c5e6d5dfb5 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling net2 v0.2.26
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/net2-0.2.26/src/lib.rs --crate-name net2 --crate-type lib -g --cfg feature=\"default\" --cfg feature=\"duration\" -C metadata=9d6e96a2c1cbefe5 -C extra-filename=-9d6e96a2c1cbefe5 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern cfg_if=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libcfg_if-292f14b70981a79c.rlib --extern libc=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblibc-b2b114c5e6d5dfb5.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling mio v0.6.4
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/mio-0.6.4/src/lib.rs --crate-name mio --crate-type lib -g -C metadata=d099e873393bed4f -C extra-filename=-d099e873393bed4f --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern libc=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblibc-b2b114c5e6d5dfb5.rlib --extern net2=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libnet2-9d6e96a2c1cbefe5.rlib --extern log=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblog-b637bf0b0680ab8d.rlib --extern slab=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libslab-5b6cda3fc92c5c7a.rlib --extern lazycell=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblazycell-be9e96c765fb82f1.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling tokio-core v0.1.4 (https://github.com/tokio-rs/tokio-core#bd75a522)
     Running `rustc /root/.cargo/git/checkouts/tokio-core-ec1bf80948dd483b/bd75a522c3d58c09b67d5ae2942e085918b599cb/src/lib.rs --crate-name tokio_core --crate-type lib -g -C metadata=9cde9ce10847a427 -C extra-filename=-9cde9ce10847a427 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern slab=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libslab-5b6cda3fc92c5c7a.rlib --extern futures=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libfutures-0b1038a4ee845431.rlib --extern scoped_tls=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libscoped_tls-235529888121a3a7.rlib --extern log=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblog-b637bf0b0680ab8d.rlib --extern mio=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libmio-d099e873393bed4f.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling rand v0.3.15
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/rand-0.3.15/src/lib.rs --crate-name rand --crate-type lib -g -C metadata=35167bebb3b301e7 -C extra-filename=-35167bebb3b301e7 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern libc=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblibc-b2b114c5e6d5dfb5.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-sys-0.1.10/src/lib.rs --crate-name backtrace_sys --crate-type lib -g -C metadata=10baeafd9b43ca2a -C extra-filename=-10baeafd9b43ca2a --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern libc=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblibc-b2b114c5e6d5dfb5.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort -L native=/source/./target/x86_64-unknown-linux-gnu/debug/build/backtrace-sys-6f090e84bbeeafba/out/.libs -l static=backtrace`
   Compiling kernel32-sys v0.2.2
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/kernel32-sys-0.2.2/build.rs --crate-name build_script_build --crate-type bin -g -C metadata=d6afa5bd3d7cfaef --out-dir /source/./target/debug/build/kernel32-sys-d6afa5bd3d7cfaef --emit=dep-info,link -L dependency=/source/./target/debug/deps --extern build=/source/./target/debug/deps/libbuild-62810576f9e98607.rlib --cap-lints allow`
     Running `/source/./target/debug/build/kernel32-sys-d6afa5bd3d7cfaef/build-script-build`
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/kernel32-sys-0.2.2/src/lib.rs --crate-name kernel32 --crate-type lib -g -C metadata=41e6ca7616688a49 -C extra-filename=-41e6ca7616688a49 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern winapi=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libwinapi-497ae3b05d554b01.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
     Running `/source/./target/debug/build/dbghelp-sys-63f6e37cae1a7d6b/build-script-build`
     Running `/source/./target/debug/build/backtrace-4d922e79d0b3f0f4/build-script-build`
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/dbghelp-sys-0.2.0/src/lib.rs --crate-name dbghelp --crate-type lib -g -C metadata=a19b390daa7ad49f -C extra-filename=-a19b390daa7ad49f --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern winapi=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libwinapi-497ae3b05d554b01.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling byteorder v1.0.0
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/byteorder-1.0.0/src/lib.rs --crate-name byteorder --crate-type lib -g --cfg feature=\"default\" --cfg feature=\"std\" -C metadata=77f0324d9153219f -C extra-filename=-77f0324d9153219f --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling rustc-demangle v0.1.4
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-demangle-0.1.4/src/lib.rs --crate-name rustc_demangle --crate-type lib -g -C metadata=89851a6d1db5dab5 -C extra-filename=-89851a6d1db5dab5 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.0/src/lib.rs --crate-name backtrace --crate-type lib -g --cfg feature=\"libbacktrace\" --cfg feature=\"kernel32-sys\" --cfg feature=\"coresymbolication\" --cfg feature=\"libunwind\" --cfg feature=\"dbghelp\" --cfg feature=\"backtrace-sys\" --cfg feature=\"dbghelp-sys\" --cfg feature=\"dladdr\" --cfg feature=\"default\" --cfg feature=\"winapi\" -C metadata=935fd6436fc1dd9d -C extra-filename=-935fd6436fc1dd9d --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern backtrace_sys=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libbacktrace_sys-10baeafd9b43ca2a.rlib --extern libc=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblibc-b2b114c5e6d5dfb5.rlib --extern kernel32=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libkernel32-41e6ca7616688a49.rlib --extern cfg_if=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libcfg_if-292f14b70981a79c.rlib --extern dbghelp=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libdbghelp-a19b390daa7ad49f.rlib --extern rustc_demangle=/source/./target/x86_64-unknown-linux-gnu/debug/deps/librustc_demangle-89851a6d1db5dab5.rlib --extern winapi=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libwinapi-497ae3b05d554b01.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort -L native=/source/./target/x86_64-unknown-linux-gnu/debug/build/backtrace-sys-6f090e84bbeeafba/out/.libs`
   Compiling tokio-proto v0.1.0
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-proto-0.1.0/src/lib.rs --crate-name tokio_proto --crate-type lib -g -C metadata=704baa235c14b0cb -C extra-filename=-704baa235c14b0cb --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern tokio_service=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libtokio_service-007fbbb9d287c06e.rlib --extern smallvec=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libsmallvec-127fe4715298f2bd.rlib --extern tokio_core=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libtokio_core-9cde9ce10847a427.rlib --extern rand=/source/./target/x86_64-unknown-linux-gnu/debug/deps/librand-35167bebb3b301e7.rlib --extern net2=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libnet2-9d6e96a2c1cbefe5.rlib --extern log=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblog-b637bf0b0680ab8d.rlib --extern take=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libtake-3b273b5cdb86db9c.rlib --extern futures=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libfutures-0b1038a4ee845431.rlib --extern slab=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libslab-5b6cda3fc92c5c7a.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling error-chain v0.8.1
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/error-chain-0.8.1/src/lib.rs --crate-name error_chain --crate-type lib -g --cfg feature=\"backtrace\" --cfg feature=\"default\" --cfg feature=\"example_generated\" -C metadata=faf7bc173d16b101 -C extra-filename=-faf7bc173d16b101 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern backtrace=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libbacktrace-935fd6436fc1dd9d.rlib --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort -L native=/source/./target/x86_64-unknown-linux-gnu/debug/build/backtrace-sys-6f090e84bbeeafba/out/.libs`
   Compiling quick-error v1.1.0
     Running `rustc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/quick-error-1.1.0/src/lib.rs --crate-name quick_error --crate-type lib -g -C metadata=6ad976e2462e7463 -C extra-filename=-6ad976e2462e7463 --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --cap-lints allow -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort`
   Compiling tokio-cassandra v0.0.0 (file:///source)
     Running `rustc /source/src/lib.rs --crate-name tokio_cassandra --crate-type lib -g -C metadata=8cd28d759305fa3f -C extra-filename=-8cd28d759305fa3f --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern semver=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libsemver-c35bfa6fa235102b.rlib --extern tokio_proto=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libtokio_proto-704baa235c14b0cb.rlib --extern futures=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libfutures-0b1038a4ee845431.rlib --extern tokio_core=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libtokio_core-9cde9ce10847a427.rlib --extern tokio_service=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libtokio_service-007fbbb9d287c06e.rlib --extern error_chain=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liberror_chain-faf7bc173d16b101.rlib --extern byteorder=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libbyteorder-77f0324d9153219f.rlib --extern log=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblog-b637bf0b0680ab8d.rlib --extern quick_error=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libquick_error-6ad976e2462e7463.rlib -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort -L native=/source/./target/x86_64-unknown-linux-gnu/debug/build/backtrace-sys-6f090e84bbeeafba/out/.libs`
warning: unused `#[macro_use]` import
  --> /source/src/lib.rs:14:1
   |
14 | #[macro_use]
   | ^^^^^^^^^^^^
   |
   = note: #[warn(unused_imports)] on by default

   Compiling tokio-cassandra-fuzz v0.0.1 (file:///source/fuzz)
     Running `rustc fuzzers/decoder.rs --crate-name decoder --crate-type bin -g -C metadata=51388cbfebca08bf -C extra-filename=-51388cbfebca08bf --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern tokio_core=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libtokio_core-9cde9ce10847a427.rlib --extern tokio_cassandra=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libtokio_cassandra-8cd28d759305fa3f.rlib --extern libfuzzer_sys=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblibfuzzer_sys-30281862c9b2f740.rlib -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort -L native=/source/./target/x86_64-unknown-linux-gnu/debug/build/backtrace-sys-6f090e84bbeeafba/out/.libs`
warning: unused imports: `Codec`, `EasyBuf`
 --> fuzzers/decoder.rs:6:22
  |
6 | use tokio_core::io::{EasyBuf, Codec};
  |                      ^^^^^^^  ^^^^^
  |
  = note: #[warn(unused_imports)] on by default

warning: unused variable: `data`
  --> fuzzers/decoder.rs:11:18
   |
11 | pub extern fn go(data: &[u8]) {
   |                  ^^^^
   |
   = note: #[warn(unused_variables)] on by default

warning: unused variable: `c`
  --> fuzzers/decoder.rs:12:9
   |
12 |     let c = CqlCodec::new(ProtocolVersion::Version3, Default::default());
   |         ^
   |
   = note: #[warn(unused_variables)] on by default

error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-m64" "-L" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib" "/source/./target/x86_64-unknown-linux-gnu/debug/deps/decoder-51388cbfebca08bf.0.o" "-o" "/source/./target/x86_64-unknown-linux-gnu/debug/deps/decoder-51388cbfebca08bf" "-Wl,--gc-sections" "-pie" "-nodefaultlibs" "-L" "/source/./target/x86_64-unknown-linux-gnu/debug/deps" "-L" "/source/./target/x86_64-unknown-linux-gnu/debug/build/backtrace-sys-6f090e84bbeeafba/out/.libs" "-L" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "-Wl,-Bdynamic" "/source/target/x86_64-unknown-linux-gnu/debug/deps/liblibfuzzer_sys-30281862c9b2f740.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libtokio_cassandra-8cd28d759305fa3f.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libsemver-c35bfa6fa235102b.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libsemver_parser-82acc3fab877e520.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libbyteorder-77f0324d9153219f.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libquick_error-6ad976e2462e7463.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/liberror_chain-faf7bc173d16b101.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libbacktrace-935fd6436fc1dd9d.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/librustc_demangle-89851a6d1db5dab5.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libwinapi-497ae3b05d554b01.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libkernel32-41e6ca7616688a49.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libdbghelp-a19b390daa7ad49f.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libbacktrace_sys-10baeafd9b43ca2a.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libtokio_proto-704baa235c14b0cb.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libtokio_service-007fbbb9d287c06e.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libtokio_core-9cde9ce10847a427.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libscoped_tls-235529888121a3a7.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libmio-d099e873393bed4f.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/liblazycell-be9e96c765fb82f1.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libfutures-0b1038a4ee845431.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/liblog-b637bf0b0680ab8d.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libsmallvec-127fe4715298f2bd.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libslab-5b6cda3fc92c5c7a.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/librand-35167bebb3b301e7.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libnet2-9d6e96a2c1cbefe5.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libcfg_if-292f14b70981a79c.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/liblibc-b2b114c5e6d5dfb5.rlib" "/source/target/x86_64-unknown-linux-gnu/debug/deps/libtake-3b273b5cdb86db9c.rlib" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-9a66b6a343d52844.rlib" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/libpanic_abort-bf5eab773c3965d6.rlib" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunwind-2beb731af7a6faec.rlib" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/librand-6bc49e032a89c77d.rlib" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcollections-a2a467c3ca3b6479.rlib" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-ce7b9706e1719f27.rlib" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd_unicode-e54225ff8f33e08f.rlib" "-Wl,--whole-archive" "/tmp/rustc.TJpuZlGqmALn/librustc_asan-5959eeb9b5003257.rlib" "-Wl,--no-whole-archive" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc_system-5636d8d1255715e9.rlib" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-95af4192ed69a1c8.rlib" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcore-cd0ca85e71f914ca.rlib" "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-0bf24067248742a8.rlib" "-l" "util" "-l" "dl" "-l" "rt" "-l" "pthread" "-l" "gcc_s" "-l" "pthread" "-l" "c" "-l" "m" "-l" "rt" "-l" "util"
  = note: /usr/lib/gcc/x86_64-linux-gnu/6/../../../x86_64-linux-gnu/Scrt1.o: In function `_start':
          (.text+0x20): undefined reference to `main'
          collect2: error: ld returned 1 exit status
          

error: aborting due to previous error

error: Could not compile `tokio-cassandra-fuzz`.

Caused by:
  process didn't exit successfully: `rustc fuzzers/decoder.rs --crate-name decoder --crate-type bin -g -C metadata=51388cbfebca08bf -C extra-filename=-51388cbfebca08bf --out-dir /source/./target/x86_64-unknown-linux-gnu/debug/deps --emit=dep-info,link --target x86_64-unknown-linux-gnu -L dependency=/source/./target/x86_64-unknown-linux-gnu/debug/deps --extern tokio_core=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libtokio_core-9cde9ce10847a427.rlib --extern tokio_cassandra=/source/./target/x86_64-unknown-linux-gnu/debug/deps/libtokio_cassandra-8cd28d759305fa3f.rlib --extern libfuzzer_sys=/source/./target/x86_64-unknown-linux-gnu/debug/deps/liblibfuzzer_sys-30281862c9b2f740.rlib -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=3 -Zsanitizer=address -Cpanic=abort -L native=/source/./target/x86_64-unknown-linux-gnu/debug/build/backtrace-sys-6f090e84bbeeafba/out/.libs` (exit code: 101)
make: *** [fuzz] Error 101
```