### PR TITLE
Prevent overwriting existing fuzzing scripts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ impl FuzzProject {
     /// Add a new fuzz target script with a given name
     fn create_target_template<'a>(&self, target: &str) -> Result<()> {
         let target_path = self.target_path(target);
-        let mut script = fs::File::create(path::Path::new(&target_path))?;
+        let mut script = fs::OpenOptions::new().write(true).create_new(true).open(&target_path)?;
         script.write_fmt(target_template!(self.root_project_name()?.replace("-", "_")))?;
 
         let mut cargo = fs::OpenOptions::new().append(true)


### PR DESCRIPTION
The user should remove an existent script before creating one with the same name.
In case of adding a script with an existent name, maybe you forgot of having one with the same name.
In case you run `cargo-fuzz add some_script` instead of `cargo-fuzz run some_script` and you overwrite some work done (for ex: during a day)