### PR TITLE
Fix non-replacement of binary in Travis

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,4 @@
-cargo install
+cargo install --force
 PATH=$PATH:/home/travis/.cargo/bin
 cd testcrate
 cargo build


### PR DESCRIPTION
Noticed in another [PR](https://travis-ci.org/rust-fuzz/cargo-fuzz/builds/216678704#L307).

```
$ scripts/run.sh
    Installing cargo-fuzz v0.4.0 (file:///home/travis/build/rust-fuzz/cargo-fuzz)
error: binary `cargo-fuzz` already exists in destination as part of `cargo-fuzz v0.3.1 (file:///home/travis/build/rust-fuzz/cargo-fuzz)`
Add --force to overwrite
```