### PR TITLE
Update README on how to check specific inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ $ cargo fuzz run fuzzer_script_1 # or whatever the target is named
 Then, wait till it finds something! More complex invocations are available as well. Consider
 looking at `cargo fuzz --help`, `cargo fuzz run --help` and others.
 
+Once you have found something and believe you have fixed it, re-run the fuzzer with the input:
+
+```sh
+$ cargo fuzz run fuzzer_script_1 fuzz/artifacts/fuzzer_script_1/<file mentioned in crash output>
+```
+
 ## Trophy case
 
  - [toml-rs panic](https://github.com/alexcrichton/toml-rs/issues/152)


### PR DESCRIPTION
Ultimately, this should fix #60.

There is a caveat here in that libfuzzer errors out saying it is only running the single input and won't be fuzzing and this is detected as a memleak (with a long backtrace). I can't find an option to say "*it's okay to just take this input and run it*". Might look at `libfuzzer-sys` and see what's up.

Still, this documentation is okay.