### PR TITLE
Stop the creation of files if project name is invalid

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,12 +104,14 @@ impl FuzzProject {
             targets: Vec::new(),
         };
         let fuzz_project = project.path();
+        let root_project_name = try!(project.root_project_name());
+
         // TODO: check if the project is already initialized
         fs::create_dir(&fuzz_project)?;
         fs::create_dir(fuzz_project.join("fuzzers"))?;
 
         let mut cargo = fs::File::create(fuzz_project.join("Cargo.toml"))?;
-        cargo.write_fmt(toml_template!(project.root_project_name()?))?;
+        cargo.write_fmt(toml_template!(root_project_name))?;
 
         let mut ignore = fs::File::create(fuzz_project.join(".gitignore"))?;
         ignore.write_fmt(gitignore_template!())?;


### PR DESCRIPTION
This fixes an issue I noticed whilst looking at #15.

We get the root project name and check the validity after the folders and a file have been created. This puts us in a sort of semi-setup state. Instead, check the project name before any file creation.

Note: this doesn't fix #15.