### PR TITLE
Support macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,18 @@ addons:
     - gcc-5
     - g++-5
 
-rust: nightly
-
-os:
-  - linux
+osx_image: xcode8.3
 
 matrix:
   fast_finish: true
+  include:
+    - os: linux
+      rust: nightly
+      env: CC=gcc-5 CXX=g++-5
+    - os: osx
+      rust: nightly
+      env: CC=gcc CXX=g++
+      # ^ setting them to `clang/clang++` causes a mysterious "<cstdint> not found" error.
 
 notifications:
   email: false

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,9 +3,9 @@ PATH=$PATH:/home/travis/.cargo/bin
 cd testcrate
 cargo build
 cargo-fuzz init
-sed -i 's/\/\/.*/testcrate\:\:test_func\(data\)\;/g' fuzz/fuzzers/fuzzer_script_1.rs
+sed -i'' -e 's/\/\/.*/testcrate\:\:test_func\(data\)\;/g' fuzz/fuzzers/fuzzer_script_1.rs
 
-if CC=gcc-5 CXX=g++-5 cargo-fuzz run fuzzer_script_1 -- -runs=1000; then
+if cargo-fuzz run fuzzer_script_1 -- -runs=1000; then
     exit 100; # Should not succeed!
 else
     :;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,8 @@ fn main() {
                  .help("custom corpus directory or artefact files"))
             .arg(Arg::with_name("ARGS").multiple(true).last(true)
                  .help("additional libFuzzer arguments passed to the binary"))
+            .arg(Arg::with_name("TRIPLE").long("target")
+                 .help("target triple of the fuzz target"))
         )
         .subcommand(SubCommand::with_name("add").about("Add a new fuzz target")
                     .arg(Arg::with_name("TARGET").required(true)
@@ -166,7 +168,7 @@ impl FuzzProject {
         let corpus = args.values_of_os("CORPUS");
         let exec_args = args.values_of_os("ARGS")
                             .map(|v| v.collect::<Vec<_>>());
-        let target_triple = "x86_64-unknown-linux-gnu";
+        let target_triple = args.value_of_os("TRIPLE").unwrap_or_else(utils::default_target);
 
         let other_flags = env::var("RUSTFLAGS").unwrap_or_default();
         let mut rustflags: String = format!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use std::io::Write;
+use std::ffi::OsStr;
 use term;
 
 #[allow(dead_code)]
@@ -32,4 +33,16 @@ pub fn report_error(e: &super::Error) {
         red("  caused by:");
         let _ = writeln!(::std::io::stderr(), " {}", e);
     }
+}
+
+/// The default target to pass to cargo, to workaround issue #11.
+#[cfg(target_os="macos")]
+pub fn default_target() -> &'static OsStr {
+    OsStr::new("x86_64-apple-darwin")
+}
+
+/// The default target to pass to cargo, to workaround issue #11.
+#[cfg(not(target_os="macos"))]
+pub fn default_target() -> &'static OsStr {
+    OsStr::new("x86_64-unknown-linux-gnu")
 }


### PR DESCRIPTION
Fix #36. 

rustc enabled ASan and TSan on macOS starting from 1.18.0-nightly (036983201 2017-04-26), so no special change is needed to enable macOS support, aside from relaxing the target check.

This PR adds the `--target` flag to let the user specify the target triple. By default, the target is set to `x86_64-apple-darwin` on macOS, and `x86_64-unknown-linux-gnu` everywhere else, to avoid  changing too much from #34.