### PR TITLE
Implement parallel fuzzing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,15 @@ description = "Simple wrapper around libFuzzer"
 repository = "https://github.com/rust-fuzz/cargo-fuzz/"
 
 [dependencies]
-toml            = "0.3"
-term            = "0.4"
-clap            = "2.21.1"
+clap            = "2.24"
 error-chain     = "0.10"
+futures         = "0.1"
+term            = "0.4"
+tokio-core      = "0.1"
+tokio-io        = "0.1"
+tokio-process   = "0.1"
+toml            = "0.3"
+
 
 [workspace]
 members = ["."]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,4 @@
 use std::io::Write;
-use std::ffi::OsStr;
 use term;
 
 #[allow(dead_code)]
@@ -37,12 +36,12 @@ pub fn report_error(e: &super::Error) {
 
 /// The default target to pass to cargo, to workaround issue #11.
 #[cfg(target_os="macos")]
-pub fn default_target() -> &'static OsStr {
-    OsStr::new("x86_64-apple-darwin")
+pub fn default_target() -> &'static str {
+    "x86_64-apple-darwin"
 }
 
 /// The default target to pass to cargo, to workaround issue #11.
 #[cfg(not(target_os="macos"))]
-pub fn default_target() -> &'static OsStr {
-    OsStr::new("x86_64-unknown-linux-gnu")
+pub fn default_target() -> &'static str {
+    "x86_64-unknown-linux-gnu"
 }


### PR DESCRIPTION
It is possible to run multiple fuzzing processes at the same time, thus
improving fuzzing speed signinficantly. One problem with the built-in
fuzzing is that it is bad at displaying information on the go.

Therefore we implement our own process mangement (using the awesome
tokio) and print results from all of them on the fly.

Also fixes the CLI for `--target`.