### PR TITLE
workaround for issue #100

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -311,6 +311,7 @@ impl FuzzProject {
              -Cpasses=sancov \
              -Cllvm-args=-sanitizer-coverage-level=3 \
              -Zsanitizer={sanitizer} \
+             -Clink-args=-Wl,-Ttext-segment=0x200000000000 \
              -Cpanic=abort",
             sanitizer = sanitizer,
         );


### PR DESCRIPTION
Using link-args, we force the load address for the executable to be higher than
the shadow memory area required by address sanitizer.