### PR TITLE
Attempt to fix GitHub license detection by mentioning license in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,9 @@ throughout every dependency.
 The trophy case has moved to a separate dedicated repository:
 
 https://github.com/rust-fuzz/trophy-case
+
+## License
+
+cargo-fuzz is distributed under the terms of both the MIT license and the Apache License (Version 2.0).
+
+See [LICENSE-APACHE](./LICENSE-APACHE) and [LICENSE-MIT](./LICENSE-MIT) for details.


### PR DESCRIPTION
GitHub thinks this repo is just Apache 2.0. See also https://github.com/rust-lang/rust/issues/43188