### PR TITLE
tmin's CRASHES argument is required

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,7 @@ Some useful options (to be used as `cargo fuzz run fuzz_target -- <options>`) in
                       _ => return Ok(()),
                   }))))
              .arg(Arg::with_name("CRASH")
+                  .required(true)
                   .help("Crashing test case to minimize"))
         )
         .subcommand(SubCommand::with_name("add").about("Add a new fuzz target")


### PR DESCRIPTION
tmin requires the `CRASHES` argument, but nobody told `clap`, so it panics:

```
% cargo fuzz tmin blah
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /checkout/src/libcore/option.rs:335:20
```
