### PR TITLE
Enable more coverage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -310,7 +310,12 @@ impl FuzzProject {
         let mut rustflags: String = format!(
             "--cfg fuzzing \
              -Cpasses=sancov \
-             -Cllvm-args=-sanitizer-coverage-level=3 \
+             -Cllvm-args=-sanitizer-coverage-level=4 \
+             -Cllvm-args=-sanitizer-coverage-trace-pc-guard \
+             -Cllvm-args=-sanitizer-coverage-trace-compares \
+             -Cllvm-args=-sanitizer-coverage-trace-divs \
+             -Cllvm-args=-sanitizer-coverage-trace-geps \
+             -Cllvm-args=-sanitizer-coverage-prune-blocks=0 \
              -Zsanitizer={sanitizer} \
              -Cpanic=abort",
             sanitizer = sanitizer,

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,7 +311,7 @@ impl FuzzProject {
             "--cfg fuzzing \
              -Cpasses=sancov \
              -Cllvm-args=-sanitizer-coverage-level=4 \
-             -Cllvm-args=-sanitizer-coverage-trace-pc-guard \
+             {pc_guard} \
              -Cllvm-args=-sanitizer-coverage-trace-compares \
              -Cllvm-args=-sanitizer-coverage-trace-divs \
              -Cllvm-args=-sanitizer-coverage-trace-geps \
@@ -319,6 +319,9 @@ impl FuzzProject {
              -Zsanitizer={sanitizer} \
              -Cpanic=abort",
             sanitizer = sanitizer,
+            // there is a bug in rustc/llvm which makes this flags trigger a build failure on OS X
+            // see: https://github.com/rust-lang/rust/issues/45762
+            pc_guard = if cfg!(target_os = "macos") {""} else {"-Cllvm-args=-sanitizer-coverage-trace-pc-guard"}
         );
         if args.is_present("debug_assertions") {
             rustflags.push_str(" -Cdebug-assertions");


### PR DESCRIPTION
  - sanitizer-coverage-level=4
  Use 4 instead of 3 to enable the tracing of indirect calls.
  This level is undocumented but it's the only way AFAIK to enable
  this functionnality in rustc.
  Here is the code describing the 4th level: [link](https://code.woboq.org/llvm/llvm/lib/Transforms/Instrumentation/SanitizerCoverage.cpp.html#151)
  Here we can see that this functionnality is used by libFuzzer: [link](https://github.com/rust-fuzz/libfuzzer-sys/blob/master/llvm/lib/Fuzzer/FuzzerTracePC.cpp#L302)
  Here we can see that this functionnality is used by Honggfuzz: [link](https://github.com/google/honggfuzz/blob/master/libhfuzz/instrument.c#L224)
  and enabled by default in their compiler wrapper: [link](https://github.com/google/honggfuzz/blob/master/hfuzz_cc/hfuzz-cc.c#L268)
  and recommended to use in their documentation: [link](https://github.com/google/honggfuzz/blob/master/docs/FeedbackDrivenFuzzing.md)
  OSS-Fuzz enables it for Hongfuzz: [link](https://github.com/google/oss-fuzz/blob/master/infra/base-images/base-builder/compile_honggfuzz#L31)

  - sanitizer-coverage-prune-blocks=0
  Disable pruning. Explanation here: [link](https://clang.llvm.org/docs/SanitizerCoverage.html#id6)
  OSS-Fuzz does it: [link](https://github.com/google/oss-fuzz/blob/master/infra/base-images/base-builder/Dockerfile#L33)
  Honggfuzz does it: [link](https://github.com/google/honggfuzz/blob/master/hfuzz_cc/hfuzz-cc.c#L270)
  In AFL, it seems that the flags was removed because it was
  "redondant": [link](https://github.com/mirrorer/afl/commit/418e426bdad9d2c659911bc2613ddfabfcfada94)
  I don't know if it's also redondant in our case, I haven't found any
  evidence in LLVM source code and it's explicitly enabled in LibFuzzer
  and Honggfuzz so I think it's better to enable it explicitly anyway.

  - sanitizer-coverage-trace-compares
  It's enabled by default in libFuzzer (and therefore OSS-Fuzz): [link](https://llvm.org/docs/LibFuzzer.html#tracing-cmp-instructions)
  It's enabled by default in Honggfuzz: [link](https://github.com/google/honggfuzz/blob/master/hfuzz_cc/hfuzz-cc.c#L268) , [link](https://github.com/google/honggfuzz/blob/master/docs/FeedbackDrivenFuzzing.md)

  - sanitizer-coverage-trace-divs and sanitizer-coverage-trace-geps
  It's probably enabled by default in libFuzzer (and therefore OSS-Fuzz): [link](https://llvm.org/docs/LibFuzzer.html#tracing-cmp-instructions)
  It's implemented in libFuzzer: [link](https://github.com/rust-fuzz/libfuzzer-sys/blob/master/llvm/lib/Fuzzer/FuzzerTracePC.cpp#L369-L385)

  - sanitizer-coverage-trace-pc-guard
  I guess this one is already enabled by default but I thought it
  was sensible to include it explicitly for completeness