### PR TITLE
Re-enable -sanitizer-coverage-trace-pc-guard for macOS.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -307,21 +307,21 @@ impl FuzzProject {
             cmd.arg("--features").arg(value);
         }
 
+        // codegen-units=1 is needed to work around a rustc bug:
+        // https://github.com/rust-lang/rust/issues/47071
         let mut rustflags: String = format!(
             "--cfg fuzzing \
              -Cpasses=sancov \
              -Cllvm-args=-sanitizer-coverage-level=4 \
-             {pc_guard} \
+             -Cllvm-args=-sanitizer-coverage-trace-pc-guard \
              -Cllvm-args=-sanitizer-coverage-trace-compares \
              -Cllvm-args=-sanitizer-coverage-trace-divs \
              -Cllvm-args=-sanitizer-coverage-trace-geps \
              -Cllvm-args=-sanitizer-coverage-prune-blocks=0 \
              -Zsanitizer={sanitizer} \
-             -Cpanic=abort",
+             -Cpanic=abort \
+             -Ccodegen-units=1",
             sanitizer = sanitizer,
-            // there is a bug in rustc/llvm which makes this flags trigger a build failure on OS X
-            // see: https://github.com/rust-lang/rust/issues/45762
-            pc_guard = if cfg!(target_os = "macos") {""} else {"-Cllvm-args=-sanitizer-coverage-trace-pc-guard"}
         );
         if args.is_present("debug_assertions") {
             rustflags.push_str(" -Cdebug-assertions");


### PR DESCRIPTION
The rustc bug can be avoided by specifying codegen units to 1.