### PR TITLE
Do not compile with `panic=abort`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -316,8 +316,7 @@ impl FuzzProject {
              -Cllvm-args=-sanitizer-coverage-trace-divs \
              -Cllvm-args=-sanitizer-coverage-trace-geps \
              -Cllvm-args=-sanitizer-coverage-prune-blocks=0 \
-             -Zsanitizer={sanitizer} \
-             -Cpanic=abort",
+             -Zsanitizer={sanitizer}",
             sanitizer = sanitizer,
             // there is a bug in rustc/llvm which makes this flags trigger a build failure on OS X
             // see: https://github.com/rust-lang/rust/issues/45762


### PR DESCRIPTION
Please merge this after https://github.com/rust-fuzz/libfuzzer-sys/pull/32
or else the fuzzer will stop being able to tell apart bugs.

fixes #152