### PR TITLE
Update template.rs to conform to conventions

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -3,7 +3,7 @@ macro_rules! toml_template {
 format_args!(r##"
 [package]
 name = "{0}-fuzz"
-version = "0.0.1"
+version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 


### PR DESCRIPTION
It's conventional for crates that are used as tools to develop other crates (such as the fuzzing crates that this tool creates) to have a version number of 0.0.0 to signify that they aren't published. This fairly simply makes this tool adhere to the convention.