### PR TITLE
Don't merge Cargo.tomls when looking for project root

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -592,6 +592,7 @@ fn find_package() -> Result<path::PathBuf> {
         match fs::File::open(&manifest_path) {
             Err(_) => {},
             Ok(mut f) => {
+                data.clear();
                 f.read_to_end(&mut data)?;
                 let value: toml::Value = toml::from_slice(&data)
                     .chain_err(||


### PR DESCRIPTION
The find_package function attempts to discover the project root by
walking up the directory hierarchy and looking for a Cargo.toml file
without the `cargo-fuzz` metadata key set. The function was accidentally
*merging* all the Cargo.tomls together, however, by not clearing out the
buffer it was reading each Cargo.toml into, resulting in extremely
confusing behavior.