### PR TITLE
Output newline at the end of error reports

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,10 +26,10 @@ fn red(s: &str) {
 
 pub fn report_error(e: &super::Error) {
     red("error:");
-    eprint!(" {}", e);
+    eprintln!(" {}", e);
     for e in e.iter().skip(1) {
         red("  caused by:");
-        eprint!(" {}", e);
+        eprintln!(" {}", e);
     }
 }
 


### PR DESCRIPTION
Thank you for creating an awesome tool.

While trying this tool, I noticed that newline is not put at the end of error report:

![スクリーンショット 2019-10-24 12 08 48](https://user-images.githubusercontent.com/823277/67450175-7fe7dc00-f657-11e9-8c3a-3817b7e31697.png)

(The last `%` means no newline at the end)

This PR fixes it by outputting newline at the end of error report.