### PR TITLE
Disable dead stripping

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -345,6 +345,7 @@ impl FuzzProject {
              -Cllvm-args=-sanitizer-coverage-trace-geps \
              -Cllvm-args=-sanitizer-coverage-prune-blocks=0 \
              -Cllvm-args=-sanitizer-coverage-pc-table \
+             -Clink-dead-code \
              -Zsanitizer={sanitizer}",
             sanitizer = sanitizer,
         );


### PR DESCRIPTION
With dead stripping, some optimized targets would fail to start fuzzing with the following error:

```
ERROR: The size of coverage PC tables does not match the
number of instrumented PCs. This might be a compiler bug,
please contact the libFuzzer developers.
Also check https://bugs.llvm.org/show_bug.cgi?id=34636
for possible workarounds (tl;dr: don't use the old GNU ld)
```

If you'd like to reproduce the issue, clone https://github.com/cloudflare/quiche and run `cargo fuzz run packet_recv_client --release` from the fuzz directory. You should see the above error. 

This PR disables dead stripping, which removes the above error. Alternatively, one could use ld.gold by adding `-Clink-arg=-fuse-ld=gold` to RUSTFLAGS. This would also fix the error. However, I did not want to assume that ld.gold was present on users' systems. Others have also successfully switched to disabling dead stripping, like [OSS-Fuzz](https://github.com/google/oss-fuzz/issues/1042), so it seemed like a better solution.

**Environment**
cargo-fuzz 0.5.4
cargo 1.41.0-nightly (8280633db 2019-11-11)
rustc 1.41.0-nightly (3e525e3f6 2019-11-18)
Debian bullseye container running on Mac OS 10.15.1 and Docker Desktop 2.1.0.5