### PR TITLE
Add support for a top level --no-color to disable color output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+/.idea

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ fn main() {
              .possible_value("fuzz")
              .required(false)
              .hidden(true))
+        .arg(Arg::with_name("no-color").long("no-color"))
         .subcommand(SubCommand::with_name("init")
             .about("Initialize the fuzz folder")
             .arg(Arg::with_name("target")
@@ -126,28 +127,26 @@ Some useful options (to be used as `cargo fuzz run fuzz_target -- <options>`) in
         )
         .subcommand(SubCommand::with_name("list").about("List all fuzz targets"));
     let args = app.get_matches();
+    let term =
+        utils::TermOutputWrapper::new(!args.is_present("no-color"));
 
     process::exit(
         match args.subcommand() {
-            ("init", matches) => FuzzProject::init(matches.expect("arguments present")).map(|_| ()),
-            ("add", matches) => {
-                FuzzProject::new().and_then(|p| p.add_target(matches.expect("arguments present")))
-            }
-            ("list", _) => FuzzProject::new().and_then(|p| p.list_targets()),
-            ("run", matches) => {
-                FuzzProject::new().and_then(|p| p.exec_fuzz(matches.expect("arguments present")))
-            }
-            ("cmin", matches) => {
-                FuzzProject::new().and_then(|p| p.exec_cmin(matches.expect("arguments present")))
-            }
-            ("tmin", matches) => {
-                FuzzProject::new().and_then(|p| p.exec_tmin(matches.expect("arguments present")))
-            }
+            ("init", matches) => FuzzProject::init(term, matches.expect("arguments present")).map(|_| ()),
+            ("add", matches) => FuzzProject::new(term)
+                .and_then(|p| p.add_target(matches.expect("arguments present"))),
+            ("list", _) => FuzzProject::new(term).and_then(|p| p.list_targets()),
+            ("run", matches) => FuzzProject::new(term)
+                .and_then(|p| p.exec_fuzz(matches.expect("arguments present"))),
+            ("cmin", matches) => FuzzProject::new(term)
+                .and_then(|p| p.exec_cmin(matches.expect("arguments present"))),
+            ("tmin", matches) => FuzzProject::new(term)
+                .and_then(|p| p.exec_tmin(matches.expect("arguments present"))),
             (s, _) => panic!("unimplemented subcommand {}!", s),
         }
         .map(|_| 0)
         .unwrap_or_else(|err| {
-            utils::report_error(&err);
+            term.report_error(&err);
             1
         }),
     );
@@ -221,13 +220,15 @@ struct FuzzProject {
     /// Not the project with fuzz targets, but the project being fuzzed
     root_project: path::PathBuf,
     targets: Vec<String>,
+    term: utils::TermOutputWrapper,
 }
 
 impl FuzzProject {
-    fn new() -> Result<Self> {
+    fn new(term: utils::TermOutputWrapper) -> Result<Self> {
         let mut project = FuzzProject {
             root_project: find_package()?,
             targets: Vec::new(),
+            term,
         };
         let manifest = project.manifest()?;
         if !is_fuzz_manifest(&manifest) {
@@ -246,10 +247,11 @@ impl FuzzProject {
     /// Create the fuzz project structure
     ///
     /// This will not clone libfuzzer-sys
-    fn init(args: &ArgMatches) -> Result<Self> {
+    fn init(term: utils::TermOutputWrapper, args: &ArgMatches) -> Result<Self> {
         let project = FuzzProject {
             root_project: find_package()?,
             targets: Vec::new(),
+            term
         };
         let fuzz_project = project.path();
         let root_project_name = project.root_project_name()?;
@@ -278,7 +280,7 @@ impl FuzzProject {
 
     fn list_targets(&self) -> Result<()> {
         for bin in &self.targets {
-            utils::print_message(bin, term::color::GREEN);
+            self.term.print_message(bin, term::color::GREEN);
         }
         Ok(())
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,34 +1,53 @@
 use term;
 
-#[allow(dead_code)]
-pub fn print_message(msg: &str, color: term::color::Color) {
-    let term_stdout = term::stdout();
+#[derive(Clone, Copy)]
+pub struct TermOutputWrapper {
+    color: bool,
+}
 
-    if let Some(mut terminal) = term_stdout {
-        let _ = terminal.fg(color);
-        println!("{}", msg);
-        let _ = terminal.reset();
-    } else {
-        println!("{}", msg);
+impl TermOutputWrapper {
+    pub fn new(color: bool) -> TermOutputWrapper {
+        TermOutputWrapper { color }
     }
-}
 
-fn red(s: &str) {
-    let mut term_stderr = term::stderr();
-    term_stderr.as_mut().map(|t| {
-        let _ = t.attr(term::Attr::Bold);
-        let _ = t.fg(term::color::RED);
-    });
-    eprint!("{}", s);
-    let _ = term_stderr.map(|mut t| t.reset());
-}
+    #[allow(dead_code)]
+    pub fn print_message(&self, msg: &str, color: term::color::Color) {
+        let term_stdout = term::stdout();
 
-pub fn report_error(e: &super::Error) {
-    red("error:");
-    eprintln!(" {}", e);
-    for e in e.iter().skip(1) {
-        red("  caused by:");
+        if self.color {
+            if let Some(mut terminal) = term_stdout {
+                let _ = terminal.fg(color);
+                println!("{}", msg);
+                let _ = terminal.reset();
+            } else {
+                println!("{}", msg);
+            }
+        } else {
+            println!("{}", msg);
+        }
+    }
+
+    fn red(&self, s: &str) {
+        if self.color {
+            let mut term_stderr = term::stderr();
+            term_stderr.as_mut().map(|t| {
+                let _ = t.attr(term::Attr::Bold);
+                let _ = t.fg(term::color::RED);
+            });
+            eprint!("{}", s);
+            let _ = term_stderr.map(|mut t| t.reset());
+        } else {
+            eprint!("{}", s);
+        }
+    }
+
+    pub fn report_error(&self, e: &super::Error) {
+        self.red("error:");
         eprintln!(" {}", e);
+        for e in e.iter().skip(1) {
+            self.red("  caused by:");
+            eprintln!(" {}", e);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #167. This makes it easier to consume output in scripts since escape characters confuse common text-manipulation tools. (Terminal detection doesn't always work.)

Green:

```
TERM=xterm cg run -- list
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/cargo-fuzz list`
fuzz_target_1
```

No green:

```
TERM=xterm cg run -- --no-color list
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/cargo-fuzz --no-color list`
fuzz_target_1
```

No green, `TERM` at default for my terminal (`xterm-256color`):

```
cg run -- list
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/cargo-fuzz list`
fuzz_target_1
```