### PR TITLE
Build subcommand + running fuzz targets on specific inputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,4 +15,5 @@ jobs:
       run: |
         rustup install nightly
         rustup default nightly
+        export RUST_BACKTRACE=1
         cargo test --verbose

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,6 @@ trait RunCommand {
         .possible_value("fuzz")
         .required(false)
         .hidden(true)),
-
 )]
 enum Command {
     /// Initialize the fuzz directory
@@ -94,6 +93,9 @@ enum Command {
 
     /// Add a new fuzz target
     Add(options::Add),
+
+    /// Build fuzz targets
+    Build(options::Build),
 
     /// List all the existing fuzz targets
     List(options::List),
@@ -118,6 +120,7 @@ impl RunCommand for Command {
         match self {
             Command::Init(x) => x.run_command(),
             Command::Add(x) => x.run_command(),
+            Command::Build(x) => x.run_command(),
             Command::List(x) => x.run_command(),
             Command::Run(x) => x.run_command(),
             Command::Cmin(x) => x.run_command(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use anyhow::Result;
-use std::fmt;
-use std::str::FromStr;
 use structopt::StructOpt;
 
 #[macro_use]
@@ -126,91 +124,6 @@ impl RunCommand for Command {
             Command::Tmin(x) => x.run_command(),
         }
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum Sanitizer {
-    Address,
-    Leak,
-    Memory,
-    Thread,
-}
-
-impl fmt::Display for Sanitizer {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Sanitizer::Address => "address",
-                Sanitizer::Leak => "leak",
-                Sanitizer::Memory => "memory",
-                Sanitizer::Thread => "thread",
-            }
-        )
-    }
-}
-
-impl FromStr for Sanitizer {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "address" => Ok(Sanitizer::Address),
-            "leak" => Ok(Sanitizer::Leak),
-            "memory" => Ok(Sanitizer::Memory),
-            "thread" => Ok(Sanitizer::Thread),
-            _ => Err(format!("unknown sanitizer: {}", s)),
-        }
-    }
-}
-
-#[derive(Clone, Debug, StructOpt)]
-pub struct BuildOptions {
-    #[structopt(short = "O", long = "release")]
-    /// Build artifacts in release mode, with optimizations
-    release: bool,
-
-    #[structopt(short = "a", long = "debug-assertions")]
-    /// Build artifacts with debug assertions enabled (default if not -O)
-    debug_assertions: bool,
-
-    #[structopt(long = "no-default-features")]
-    /// Build artifacts with default Cargo features disabled
-    no_default_features: bool,
-
-    #[structopt(
-        long = "all-features",
-        conflicts_with = "no-default-features",
-        conflicts_with = "features"
-    )]
-    /// Build artifacts with all Cargo features enabled
-    all_features: bool,
-
-    #[structopt(long = "features")]
-    /// Build artifacts with given Cargo feature enabled
-    features: Option<String>,
-
-    #[structopt(
-        short = "s",
-        long = "sanitizer",
-        possible_values(&["address", "leak", "memory", "thread"]),
-        default_value = "address",
-    )]
-    /// Use a specific sanitizer
-    sanitizer: Sanitizer,
-
-    #[structopt(
-        name = "triple",
-        long = "target",
-        default_value(utils::default_target())
-    )]
-    /// Target triple of the fuzz target
-    triple: String,
-
-    #[structopt(required(true))]
-    /// Name of the fuzz target
-    target: String,
 }
 
 fn main() -> Result<()> {

--- a/src/options.rs
+++ b/src/options.rs
@@ -6,3 +6,92 @@ mod run;
 mod tmin;
 
 pub use self::{add::Add, cmin::Cmin, init::Init, list::List, run::Run, tmin::Tmin};
+
+use std::fmt;
+use std::str::FromStr;
+use structopt::StructOpt;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Sanitizer {
+    Address,
+    Leak,
+    Memory,
+    Thread,
+}
+
+impl fmt::Display for Sanitizer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Sanitizer::Address => "address",
+                Sanitizer::Leak => "leak",
+                Sanitizer::Memory => "memory",
+                Sanitizer::Thread => "thread",
+            }
+        )
+    }
+}
+
+impl FromStr for Sanitizer {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "address" => Ok(Sanitizer::Address),
+            "leak" => Ok(Sanitizer::Leak),
+            "memory" => Ok(Sanitizer::Memory),
+            "thread" => Ok(Sanitizer::Thread),
+            _ => Err(format!("unknown sanitizer: {}", s)),
+        }
+    }
+}
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct BuildOptions {
+    #[structopt(short = "O", long = "release")]
+    /// Build artifacts in release mode, with optimizations
+    pub release: bool,
+
+    #[structopt(short = "a", long = "debug-assertions")]
+    /// Build artifacts with debug assertions enabled (default if not -O)
+    pub debug_assertions: bool,
+
+    #[structopt(long = "no-default-features")]
+    /// Build artifacts with default Cargo features disabled
+    pub no_default_features: bool,
+
+    #[structopt(
+        long = "all-features",
+        conflicts_with = "no-default-features",
+        conflicts_with = "features"
+    )]
+    /// Build artifacts with all Cargo features enabled
+    pub all_features: bool,
+
+    #[structopt(long = "features")]
+    /// Build artifacts with given Cargo feature enabled
+    pub features: Option<String>,
+
+    #[structopt(
+        short = "s",
+        long = "sanitizer",
+        possible_values(&["address", "leak", "memory", "thread"]),
+        default_value = "address",
+    )]
+    /// Use a specific sanitizer
+    pub sanitizer: Sanitizer,
+
+    #[structopt(
+        name = "triple",
+        long = "target",
+        default_value(crate::utils::default_target())
+    )]
+    /// Target triple of the fuzz target
+    pub triple: String,
+
+    #[structopt(required(true))]
+    /// Name of the fuzz target
+    pub target: String,
+}

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,11 +1,12 @@
 mod add;
+mod build;
 mod cmin;
 mod init;
 mod list;
 mod run;
 mod tmin;
 
-pub use self::{add::Add, cmin::Cmin, init::Init, list::List, run::Run, tmin::Tmin};
+pub use self::{add::Add, build::Build, cmin::Cmin, init::Init, list::List, run::Run, tmin::Tmin};
 
 use std::fmt;
 use std::str::FromStr;

--- a/src/options.rs
+++ b/src/options.rs
@@ -90,8 +90,4 @@ pub struct BuildOptions {
     )]
     /// Target triple of the fuzz target
     pub triple: String,
-
-    #[structopt(required(true))]
-    /// Name of the fuzz target
-    pub target: String,
 }

--- a/src/options/build.rs
+++ b/src/options/build.rs
@@ -1,0 +1,19 @@
+use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
+use anyhow::Result;
+use structopt::StructOpt;
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct Build {
+    #[structopt(flatten)]
+    pub build: BuildOptions,
+
+    /// Name of the fuzz target to build, or build all targets if not supplied
+    pub target: Option<String>,
+}
+
+impl RunCommand for Build {
+    fn run_command(&mut self) -> Result<()> {
+        let project = FuzzProject::find_existing()?;
+        project.exec_build(&self.build, self.target.as_ref().map(|s| s.as_str()))
+    }
+}

--- a/src/options/cmin.rs
+++ b/src/options/cmin.rs
@@ -1,4 +1,4 @@
-use crate::{project::FuzzProject, BuildOptions, RunCommand};
+use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
 use anyhow::Result;
 use std::path::PathBuf;
 use structopt::StructOpt;

--- a/src/options/cmin.rs
+++ b/src/options/cmin.rs
@@ -8,6 +8,10 @@ pub struct Cmin {
     #[structopt(flatten)]
     pub build: BuildOptions,
 
+    #[structopt(required(true))]
+    /// Name of the fuzz target
+    pub target: String,
+
     #[structopt(parse(from_os_str))]
     /// The corpus directory to minify into
     pub corpus: Option<PathBuf>,

--- a/src/options/run.rs
+++ b/src/options/run.rs
@@ -7,6 +7,10 @@ pub struct Run {
     #[structopt(flatten)]
     pub build: BuildOptions,
 
+    #[structopt(required(true))]
+    /// Name of the fuzz target
+    pub target: String,
+
     /// Custom corpus directories or artifact files.
     pub corpus: Vec<String>,
 

--- a/src/options/run.rs
+++ b/src/options/run.rs
@@ -1,4 +1,4 @@
-use crate::{project::FuzzProject, BuildOptions, RunCommand};
+use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
 use anyhow::Result;
 use structopt::StructOpt;
 

--- a/src/options/tmin.rs
+++ b/src/options/tmin.rs
@@ -1,4 +1,4 @@
-use crate::{project::FuzzProject, BuildOptions, RunCommand};
+use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
 use anyhow::Result;
 use std::path::PathBuf;
 use structopt::StructOpt;

--- a/src/options/tmin.rs
+++ b/src/options/tmin.rs
@@ -8,6 +8,10 @@ pub struct Tmin {
     #[structopt(flatten)]
     pub build: BuildOptions,
 
+    #[structopt(required(true))]
+    /// Name of the fuzz target
+    pub target: String,
+
     #[structopt(
         short = "r",
         long = "runs",

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,4 +1,4 @@
-use crate::{options, BuildOptions, Sanitizer};
+use crate::options::{self, BuildOptions, Sanitizer};
 use anyhow::{anyhow, bail, Context, Result};
 use std::io::Read;
 use std::io::Write;

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -295,3 +295,89 @@ fn tmin() {
         )
         .success();
 }
+
+#[test]
+fn build_all() {
+    let project = project("build_all").with_fuzz().build();
+
+    // Create some targets.
+    project
+        .cargo_fuzz()
+        .arg("add")
+        .arg("build_all_a")
+        .assert()
+        .success();
+    project
+        .cargo_fuzz()
+        .arg("add")
+        .arg("build_all_b")
+        .assert()
+        .success();
+
+    // Build to ensure that the build directory is created and
+    // `fuzz_build_dir()` won't panic.
+    project.cargo_fuzz().arg("build").assert().success();
+
+    let build_dir = project.fuzz_build_dir().join("debug");
+
+    let a_bin = build_dir.join("build_all_a");
+    let b_bin = build_dir.join("build_all_b");
+
+    // Remove the files we just built.
+    fs::remove_file(&a_bin).unwrap();
+    fs::remove_file(&b_bin).unwrap();
+
+    assert!(!a_bin.is_file());
+    assert!(!b_bin.is_file());
+
+    // Test that building all fuzz targets does in fact recreate the files.
+    project.cargo_fuzz().arg("build").assert().success();
+
+    assert!(a_bin.is_file());
+    assert!(b_bin.is_file());
+}
+
+#[test]
+fn build_one() {
+    let project = project("build_one").with_fuzz().build();
+
+    // Create some targets.
+    project
+        .cargo_fuzz()
+        .arg("add")
+        .arg("build_one_a")
+        .assert()
+        .success();
+    project
+        .cargo_fuzz()
+        .arg("add")
+        .arg("build_one_b")
+        .assert()
+        .success();
+
+    // Build to ensure that the build directory is created and
+    // `fuzz_build_dir()` won't panic.
+    project.cargo_fuzz().arg("build").assert().success();
+
+    let build_dir = project.fuzz_build_dir().join("debug");
+    let a_bin = build_dir.join("build_one_a");
+    let b_bin = build_dir.join("build_one_b");
+
+    // Remove the files we just built.
+    fs::remove_file(&a_bin).unwrap();
+    fs::remove_file(&b_bin).unwrap();
+
+    assert!(!a_bin.is_file());
+    assert!(!b_bin.is_file());
+
+    // Test that we can build one and not the other.
+    project
+        .cargo_fuzz()
+        .arg("build")
+        .arg("build_one_a")
+        .assert()
+        .success();
+
+    assert!(a_bin.is_file());
+    assert!(!b_bin.is_file());
+}


### PR DESCRIPTION
r? @Manishearth 

* Add tests for `cargo fuzz run <file>...`
  
  So this didn't used to work, as there was what I think was a bug where the
  default corpus was unconditionally added to the underlying command. That got
  fixed in an earlier refactoring, so this just makes sure we never regress the
  intended behavior with some tests.

* Introduce the `cargo fuzz build` subcommand

* Pull `target` out of `BuildOptions`
  
  Building in general doesn't require that you only build a single target.

* Move `BuildOptions` to the `options` submodule
  
  Just code motion.