### PR TITLE
Print `Debug` formatting of failing inputs

### DIFF
--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -215,7 +215,26 @@ fn run_with_crash() {
             predicate::str::contains("panicked at 'I'm afraid of number 7'")
                 .and(predicate::str::contains("ERROR: libFuzzer: deadly signal"))
                 .and(predicate::str::contains("run_with_crash::fail_fuzzing"))
-                .and(predicate::str::contains("fuzz/artifacts/yes_crash/crash-")),
+                .and(predicate::str::contains(
+                    "────────────────────────────────────────────────────────────────────────────────\n\
+                     \n\
+                     Failing input:\n\
+                     \n\
+                     \tfuzz/artifacts/yes_crash/crash-"
+                ))
+                // TODO: need to wait on enabling this until we release a new libfuzzer.
+                //
+                // .and(predicate::str::contains("Output of `std::fmt::Debug`:"))
+                .and(predicate::str::contains(
+                    "Reproduce with:\n\
+                     \n\
+                     \tcargo fuzz run yes_crash fuzz/artifacts/yes_crash/crash-"
+                ))
+                .and(predicate::str::contains(
+                    "Minimize test case with:\n\
+                     \n\
+                     \tcargo fuzz tmin yes_crash fuzz/artifacts/yes_crash/crash-"
+                )),
         )
         .failure();
 }

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -429,7 +429,18 @@ fn tmin() {
         .assert()
         .stderr(
             predicates::str::contains("CRASH_MIN: minimizing crash input: ")
-                .and(predicate::str::contains("(1 bytes) caused a crash")),
+                .and(predicate::str::contains("(1 bytes) caused a crash"))
+                .and(predicate::str::contains(
+                    "────────────────────────────────────────────────────────────────────────────────\n\
+                     \n\
+                     Minimized artifact:\n\
+                     \n\
+                     \tfuzz/artifacts/i_hate_zed/minimized-from-"))
+                .and(predicate::str::contains(
+                    "Reproduce with:\n\
+                     \n\
+                     \tcargo fuzz run i_hate_zed fuzz/artifacts/i_hate_zed/minimized-from-"
+                )),
         )
         .success();
 }


### PR DESCRIPTION
This PR integrates with the `RUST_LIBFUZZER_DEBUG_PATH` stuff introduced in https://github.com/rust-fuzz/libfuzzer-sys/pull/53

<details> <summary>Example debug output of fuzz crash that uses <code>Arbitrary</code></summary>

```
     Running `fuzz/target/x86_64-unknown-linux-gnu/debug/fuzz_target_1 -artifact_prefix=/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/ /home/fitzgen/scratch/cargo-project/fuzz/corpus/fuzz_target_1`
INFO: Seed: 3642727664
INFO: Loaded 1 modules   (13694 inline 8-bit counters): 13694 [0x5560f7d48b2a, 0x5560f7d4c0a8), 
INFO: Loaded 1 PC tables (13694 PCs): 13694 [0x5560f7d4c0a8,0x5560f7d81888), 
INFO:        5 files found in /home/fitzgen/scratch/cargo-project/fuzz/corpus/fuzz_target_1
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: seed corpus: files: 5 min: 1b max: 4b total: 13b rss: 28Mb
#6	INITED cov: 226 ft: 418 corp: 4/9b exec/s: 0 rss: 30Mb
thread '<unnamed>' panicked at 'success: r < g < b!', fuzz_targets/fuzz_target_1.rs:15:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
==26615== ERROR: libFuzzer: deadly signal
    #0 0x5560f77d9761 in __sanitizer_print_stack_trace /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/llvm-project/compiler-rt/lib/asan/asan_stack.cc:86:3
    #1 0x5560f782ff4f in fuzzer::PrintStackTrace() /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerUtil.cpp:205
    #2 0x5560f7833bac in fuzzer::Fuzzer::CrashCallback() /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:232
    #3 0x5560f7833a4d in fuzzer::Fuzzer::StaticCrashSignalCallback() /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:203
    #4 0x5560f78208ab in fuzzer::CrashHandler(int, siginfo_t*, void*) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerUtilPosix.cpp:47
    #5 0x7effb391888f  (/lib/x86_64-linux-gnu/libpthread.so.0+0x1288f)
    #6 0x7effb333be96 in __libc_signal_restore_set /build/glibc-OTsEL5/glibc-2.27/signal/../sysdeps/unix/sysv/linux/nptl-signals.h:80
    #7 0x7effb333be96 in gsignal /build/glibc-OTsEL5/glibc-2.27/signal/../sysdeps/unix/sysv/linux/raise.c:48
    #8 0x7effb333d800 in abort /build/glibc-OTsEL5/glibc-2.27/stdlib/abort.c:79
    #9 0x5560f7a3f486 in std::sys::unix::abort_internal::h2bbcc2e4440a6d00 /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/sys/unix/mod.rs:155:4
    #10 0x5560f7a28ea5 in std::process::abort::h4c8a022838d5876a /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/process.rs:1609:13
    #11 0x5560f785b6fa in libfuzzer_sys::initialize::_$u7b$$u7b$closure$u7d$$u7d$::h1d4662a76da6fc2e /home/fitzgen/libfuzzer-sys/src/lib.rs:51:8
    #12 0x5560f7a2f75f in std::panicking::rust_panic_with_hook::h9d80a6967ad27edd /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panicking.rs:475:16
    #13 0x5560f78b3d6a in std::panicking::begin_panic::h87a3286bc2adb99b /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panicking.rs:404:4
    #14 0x5560f7751c5d in rust_fuzzer_test_input /home/fitzgen/scratch/cargo-project/fuzz/fuzz_targets/fuzz_target_1.rs:15:12
    #15 0x5560f785b50c in libfuzzer_sys::test_input_wrap::_$u7b$$u7b$closure$u7d$$u7d$::h46a1ccb25aa965a7 /home/fitzgen/libfuzzer-sys/src/lib.rs:27:8
    #16 0x5560f785cc27 in std::panicking::try::do_call::h3fedeada154e300d /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panicking.rs:292:39
    #17 0x5560f7a40189 in __rust_maybe_catch_panic /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libpanic_unwind/lib.rs:78:7
    #18 0x5560f785c630 in std::panicking::try::hf0ec995e335d92f5 /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panicking.rs:270:12
    #19 0x5560f7859a6c in std::panic::catch_unwind::h0e25fe677a98d048 /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panic.rs:394:13
    #20 0x5560f782d88c in LLVMFuzzerTestOneInput /home/fitzgen/libfuzzer-sys/src/lib.rs:25:21
    #21 0x5560f78356ea in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:553
    #22 0x5560f7834f2b in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool*) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:469
    #23 0x5560f7836290 in fuzzer::Fuzzer::MutateAndTestOne() /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:696
    #24 0x5560f7836f3b in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:831
    #25 0x5560f78073b7 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerDriver.cpp:825
    #26 0x5560f7800504 in main /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerMain.cpp:19
    #27 0x7effb331eb96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310
    #28 0x5560f7745759 in _start (/home/fitzgen/scratch/cargo-project/fuzz/target/x86_64-unknown-linux-gnu/debug/fuzz_target_1+0x72759)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 3 ChangeByte-ShuffleBytes-InsertByte-; base unit: 1e6bf798ae804c7653ac72536b06cceae0ff1b54
0x1e,0x28,0x6e,0x2f,
\x1e(n/
artifact_prefix='/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/'; Test unit written to /home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/crash-7bb2b62488fd8fc49937ebeed3016987d6e4a554
Base64: HihuLw==

────────────────────────────────────────────────────────────────────────────────

Failing input:

	fuzz/artifacts/fuzz_target_1/crash-7bb2b62488fd8fc49937ebeed3016987d6e4a554

Output of `std::fmt::Debug`:

	Rgb {
	    r: 30,
	    g: 40,
	    b: 110,
	}

Reproduce with:

	cargo fuzz run fuzz_target_1 fuzz/artifacts/fuzz_target_1/crash-7bb2b62488fd8fc49937ebeed3016987d6e4a554

Minimize test case with:

	cargo fuzz tmin fuzz_target_1 fuzz/artifacts/fuzz_target_1/crash-7bb2b62488fd8fc49937ebeed3016987d6e4a554

────────────────────────────────────────────────────────────────────────────────

Error: Fuzz target exited with exit code: 77
```

</details>

<details> <summary>Example output of test case minimization that uses <code>Arbitrary</code></summary>

```
     Running `fuzz/target/x86_64-unknown-linux-gnu/debug/fuzz_target_1 -artifact_prefix=/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/ -minimize_crash=1 -runs=255 /home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/big-test-case`
INFO: Seed: 2980842104
INFO: Loaded 1 modules   (13694 inline 8-bit counters): 13694 [0x563b34dbeb2a, 0x563b34dc20a8), 
INFO: Loaded 1 PC tables (13694 PCs): 13694 [0x563b34dc20a8,0x563b34df7888), 
CRASH_MIN: minimizing crash input: '/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/big-test-case' (8 bytes)
CRASH_MIN: executing: fuzz/target/x86_64-unknown-linux-gnu/debug/fuzz_target_1 -artifact_prefix=/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/ -runs=255 /home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/big-test-case >/tmp/libFuzzerTemp.26546.txt 2>&1
CRASH_MIN: '/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/big-test-case' (8 bytes) caused a crash. Will try to minimize it further
CRASH_MIN: executing: fuzz/target/x86_64-unknown-linux-gnu/debug/fuzz_target_1 -artifact_prefix=/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/ -runs=255 /home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/big-test-case -minimize_crash_internal_step=1 -exact_artifact_path=/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-69bca99b923859f2dc486b55b87f49689b7358c7 >/tmp/libFuzzerTemp.26546.txt 2>&1
INFO: Seed: 3201259120
INFO: Loaded 1 modules   (13694 inline 8-bit counters): 13694 [0x5598f539db2a, 0x5598f53a10a8), 
INFO: Loaded 1 PC tables (13694 PCs): 13694 [0x5598f53a10a8,0x5598f53d6888), 
INFO: Starting MinimizeCrashInputInternalStep: 8
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 8 bytes
thread '<unnamed>' panicked at 'success: r < g < b!', fuzz_targets/fuzz_target_1.rs:15:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
==26554== ERROR: libFuzzer: deadly signal
    #0 0x5598f4e2e761 in __sanitizer_print_stack_trace /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/llvm-project/compiler-rt/lib/asan/asan_stack.cc:86:3
    #1 0x5598f4e84f4f in fuzzer::PrintStackTrace() /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerUtil.cpp:205
    #2 0x5598f4e88bac in fuzzer::Fuzzer::CrashCallback() /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:232
    #3 0x5598f4e88a4d in fuzzer::Fuzzer::StaticCrashSignalCallback() /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:203
    #4 0x5598f4e758ab in fuzzer::CrashHandler(int, siginfo_t*, void*) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerUtilPosix.cpp:47
    #5 0x7f32c4bb688f  (/lib/x86_64-linux-gnu/libpthread.so.0+0x1288f)
    #6 0x7f32c45d9e96 in __libc_signal_restore_set /build/glibc-OTsEL5/glibc-2.27/signal/../sysdeps/unix/sysv/linux/nptl-signals.h:80
    #7 0x7f32c45d9e96 in gsignal /build/glibc-OTsEL5/glibc-2.27/signal/../sysdeps/unix/sysv/linux/raise.c:48
    #8 0x7f32c45db800 in abort /build/glibc-OTsEL5/glibc-2.27/stdlib/abort.c:79
    #9 0x5598f5094486 in std::sys::unix::abort_internal::h2bbcc2e4440a6d00 /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/sys/unix/mod.rs:155:4
    #10 0x5598f507dea5 in std::process::abort::h4c8a022838d5876a /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/process.rs:1609:13
    #11 0x5598f4eb06fa in libfuzzer_sys::initialize::_$u7b$$u7b$closure$u7d$$u7d$::h1d4662a76da6fc2e /home/fitzgen/libfuzzer-sys/src/lib.rs:51:8
    #12 0x5598f508475f in std::panicking::rust_panic_with_hook::h9d80a6967ad27edd /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panicking.rs:475:16
    #13 0x5598f4f08d6a in std::panicking::begin_panic::h87a3286bc2adb99b /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panicking.rs:404:4
    #14 0x5598f4da6c5d in rust_fuzzer_test_input /home/fitzgen/scratch/cargo-project/fuzz/fuzz_targets/fuzz_target_1.rs:15:12
    #15 0x5598f4eb050c in libfuzzer_sys::test_input_wrap::_$u7b$$u7b$closure$u7d$$u7d$::h46a1ccb25aa965a7 /home/fitzgen/libfuzzer-sys/src/lib.rs:27:8
    #16 0x5598f4eb1c27 in std::panicking::try::do_call::h3fedeada154e300d /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panicking.rs:292:39
    #17 0x5598f5095189 in __rust_maybe_catch_panic /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libpanic_unwind/lib.rs:78:7
    #18 0x5598f4eb1630 in std::panicking::try::hf0ec995e335d92f5 /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panicking.rs:270:12
    #19 0x5598f4eaea6c in std::panic::catch_unwind::h0e25fe677a98d048 /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panic.rs:394:13
    #20 0x5598f4e8288c in LLVMFuzzerTestOneInput /home/fitzgen/libfuzzer-sys/src/lib.rs:25:21
    #21 0x5598f4e8a6ea in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:553
    #22 0x5598f4e8c13f in fuzzer::Fuzzer::MinimizeCrashLoop(std::vector<unsigned char, fuzzer::fuzzer_allocator<unsigned char> > const&) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:849
    #23 0x5598f4e5923c in fuzzer::MinimizeCrashInputInternalStep(fuzzer::Fuzzer*, fuzzer::InputCorpus*) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerDriver.cpp:470
    #24 0x5598f4e5bdd3 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerDriver.cpp:761
    #25 0x5598f4e55504 in main /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerMain.cpp:19
    #26 0x7f32c45bcb96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310
    #27 0x5598f4d9a759 in _start (/home/fitzgen/scratch/cargo-project/fuzz/target/x86_64-unknown-linux-gnu/debug/fuzz_target_1+0x72759)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 1 EraseBytes-; base unit: 0000000000000000000000000000000000000000
0x61,0x62,0x67,0xa,
abg\x0a
artifact_prefix='/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/'; Test unit written to /home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-69bca99b923859f2dc486b55b87f49689b7358c7
Base64: YWJnCg==
*********************************
CRASH_MIN: minimizing crash input: '/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-69bca99b923859f2dc486b55b87f49689b7358c7' (4 bytes)
CRASH_MIN: executing: fuzz/target/x86_64-unknown-linux-gnu/debug/fuzz_target_1 -artifact_prefix=/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/ -runs=255 /home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-69bca99b923859f2dc486b55b87f49689b7358c7 >/tmp/libFuzzerTemp.26546.txt 2>&1
CRASH_MIN: '/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-69bca99b923859f2dc486b55b87f49689b7358c7' (4 bytes) caused a crash. Will try to minimize it further
CRASH_MIN: executing: fuzz/target/x86_64-unknown-linux-gnu/debug/fuzz_target_1 -artifact_prefix=/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/ -runs=255 /home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-69bca99b923859f2dc486b55b87f49689b7358c7 -minimize_crash_internal_step=1 -exact_artifact_path=/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-d66b4212d48fa391835aeff8c258a626434a4f24 >/tmp/libFuzzerTemp.26546.txt 2>&1
INFO: Seed: 3522320498
INFO: Loaded 1 modules   (13694 inline 8-bit counters): 13694 [0x55799b17eb2a, 0x55799b1820a8), 
INFO: Loaded 1 PC tables (13694 PCs): 13694 [0x55799b1820a8,0x55799b1b7888), 
INFO: Starting MinimizeCrashInputInternalStep: 4
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4 bytes
thread '<unnamed>' panicked at 'success: r < g < b!', fuzz_targets/fuzz_target_1.rs:15:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
==26562== ERROR: libFuzzer: deadly signal
    #0 0x55799ac0f761 in __sanitizer_print_stack_trace /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/llvm-project/compiler-rt/lib/asan/asan_stack.cc:86:3
    #1 0x55799ac65f4f in fuzzer::PrintStackTrace() /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerUtil.cpp:205
    #2 0x55799ac69bac in fuzzer::Fuzzer::CrashCallback() /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:232
    #3 0x55799ac69a4d in fuzzer::Fuzzer::StaticCrashSignalCallback() /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:203
    #4 0x55799ac568ab in fuzzer::CrashHandler(int, siginfo_t*, void*) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerUtilPosix.cpp:47
    #5 0x7f140b7a488f  (/lib/x86_64-linux-gnu/libpthread.so.0+0x1288f)
    #6 0x7f140b1c7e96 in __libc_signal_restore_set /build/glibc-OTsEL5/glibc-2.27/signal/../sysdeps/unix/sysv/linux/nptl-signals.h:80
    #7 0x7f140b1c7e96 in gsignal /build/glibc-OTsEL5/glibc-2.27/signal/../sysdeps/unix/sysv/linux/raise.c:48
    #8 0x7f140b1c9800 in abort /build/glibc-OTsEL5/glibc-2.27/stdlib/abort.c:79
    #9 0x55799ae75486 in std::sys::unix::abort_internal::h2bbcc2e4440a6d00 /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/sys/unix/mod.rs:155:4
    #10 0x55799ae5eea5 in std::process::abort::h4c8a022838d5876a /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/process.rs:1609:13
    #11 0x55799ac916fa in libfuzzer_sys::initialize::_$u7b$$u7b$closure$u7d$$u7d$::h1d4662a76da6fc2e /home/fitzgen/libfuzzer-sys/src/lib.rs:51:8
    #12 0x55799ae6575f in std::panicking::rust_panic_with_hook::h9d80a6967ad27edd /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panicking.rs:475:16
    #13 0x55799ace9d6a in std::panicking::begin_panic::h87a3286bc2adb99b /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panicking.rs:404:4
    #14 0x55799ab87c5d in rust_fuzzer_test_input /home/fitzgen/scratch/cargo-project/fuzz/fuzz_targets/fuzz_target_1.rs:15:12
    #15 0x55799ac9150c in libfuzzer_sys::test_input_wrap::_$u7b$$u7b$closure$u7d$$u7d$::h46a1ccb25aa965a7 /home/fitzgen/libfuzzer-sys/src/lib.rs:27:8
    #16 0x55799ac92c27 in std::panicking::try::do_call::h3fedeada154e300d /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panicking.rs:292:39
    #17 0x55799ae76189 in __rust_maybe_catch_panic /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libpanic_unwind/lib.rs:78:7
    #18 0x55799ac92630 in std::panicking::try::hf0ec995e335d92f5 /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panicking.rs:270:12
    #19 0x55799ac8fa6c in std::panic::catch_unwind::h0e25fe677a98d048 /rustc/0de96d37fbcc54978458c18f5067cd9817669bc8/src/libstd/panic.rs:394:13
    #20 0x55799ac6388c in LLVMFuzzerTestOneInput /home/fitzgen/libfuzzer-sys/src/lib.rs:25:21
    #21 0x55799ac6b6ea in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:553
    #22 0x55799ac6d13f in fuzzer::Fuzzer::MinimizeCrashLoop(std::vector<unsigned char, fuzzer::fuzzer_allocator<unsigned char> > const&) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerLoop.cpp:849
    #23 0x55799ac3a23c in fuzzer::MinimizeCrashInputInternalStep(fuzzer::Fuzzer*, fuzzer::InputCorpus*) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerDriver.cpp:470
    #24 0x55799ac3cdd3 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerDriver.cpp:761
    #25 0x55799ac36504 in main /home/fitzgen/libfuzzer-sys/libfuzzer/FuzzerMain.cpp:19
    #26 0x7f140b1aab96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310
    #27 0x55799ab7b759 in _start (/home/fitzgen/scratch/cargo-project/fuzz/target/x86_64-unknown-linux-gnu/debug/fuzz_target_1+0x72759)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 1 EraseBytes-; base unit: 0000000000000000000000000000000000000000
0x61,0x62,0x67,
abg
artifact_prefix='/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/'; Test unit written to /home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-d66b4212d48fa391835aeff8c258a626434a4f24
Base64: YWJn
*********************************
CRASH_MIN: minimizing crash input: '/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-d66b4212d48fa391835aeff8c258a626434a4f24' (3 bytes)
CRASH_MIN: executing: fuzz/target/x86_64-unknown-linux-gnu/debug/fuzz_target_1 -artifact_prefix=/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/ -runs=255 /home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-d66b4212d48fa391835aeff8c258a626434a4f24 >/tmp/libFuzzerTemp.26546.txt 2>&1
CRASH_MIN: '/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-d66b4212d48fa391835aeff8c258a626434a4f24' (3 bytes) caused a crash. Will try to minimize it further
CRASH_MIN: executing: fuzz/target/x86_64-unknown-linux-gnu/debug/fuzz_target_1 -artifact_prefix=/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/ -runs=255 /home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-d66b4212d48fa391835aeff8c258a626434a4f24 -minimize_crash_internal_step=1 -exact_artifact_path=/home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-d1f85e55fba9f5b6db087e58762c7c8e370f6a57 >/tmp/libFuzzerTemp.26546.txt 2>&1
INFO: Seed: 3841027793
INFO: Loaded 1 modules   (13694 inline 8-bit counters): 13694 [0x55a88a2c0b2a, 0x55a88a2c40a8), 
INFO: Loaded 1 PC tables (13694 PCs): 13694 [0x55a88a2c40a8,0x55a88a2f9888), 
INFO: Starting MinimizeCrashInputInternalStep: 3
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 3 bytes
INFO: Done MinimizeCrashInputInternalStep, no crashes found
CRASH_MIN: failed to minimize beyond /home/fitzgen/scratch/cargo-project/fuzz/artifacts/fuzz_target_1/minimized-from-d66b4212d48fa391835aeff8c258a626434a4f24 (3 bytes), exiting

────────────────────────────────────────────────────────────────────────────────

Minimized artifact:

	fuzz/artifacts/fuzz_target_1/minimized-from-d66b4212d48fa391835aeff8c258a626434a4f24

Output of `std::fmt::Debug`:

	Rgb {
	    r: 97,
	    g: 98,
	    b: 103,
	}

Reproduce with:

	cargo fuzz run fuzz_target_1 fuzz/artifacts/fuzz_target_1/minimized-from-d66b4212d48fa391835aeff8c258a626434a4f24
```

</details>