### PR TITLE
Stop requiring any sanitizers for libfuzzer

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -18,6 +18,7 @@ pub enum Sanitizer {
     Leak,
     Memory,
     Thread,
+    None,
 }
 
 impl fmt::Display for Sanitizer {
@@ -30,6 +31,7 @@ impl fmt::Display for Sanitizer {
                 Sanitizer::Leak => "leak",
                 Sanitizer::Memory => "memory",
                 Sanitizer::Thread => "thread",
+                Sanitizer::None => "",
             }
         )
     }
@@ -44,6 +46,7 @@ impl FromStr for Sanitizer {
             "leak" => Ok(Sanitizer::Leak),
             "memory" => Ok(Sanitizer::Memory),
             "thread" => Ok(Sanitizer::Thread),
+            "none" => Ok(Sanitizer::None),
             _ => Err(format!("unknown sanitizer: {}", s)),
         }
     }
@@ -78,7 +81,7 @@ pub struct BuildOptions {
     #[structopt(
         short = "s",
         long = "sanitizer",
-        possible_values(&["address", "leak", "memory", "thread"]),
+        possible_values(&["address", "leak", "memory", "thread", "none"]),
         default_value = "address",
     )]
     /// Use a specific sanitizer

--- a/src/project.rs
+++ b/src/project.rs
@@ -150,19 +150,23 @@ impl FuzzProject {
             cmd.arg("-Z").arg(flag);
         }
 
-        let mut rustflags: String = format!(
-            "--cfg fuzzing \
-             -Cpasses=sancov \
-             -Cllvm-args=-sanitizer-coverage-level=4 \
-             -Cllvm-args=-sanitizer-coverage-trace-compares \
-             -Cllvm-args=-sanitizer-coverage-inline-8bit-counters \
-             -Cllvm-args=-sanitizer-coverage-trace-geps \
-             -Cllvm-args=-sanitizer-coverage-prune-blocks=0 \
-             -Cllvm-args=-sanitizer-coverage-pc-table \
-             -Clink-dead-code \
-             -Zsanitizer={sanitizer}",
-            sanitizer = build.sanitizer,
-        );
+        let mut rustflags: String = "--cfg fuzzing \
+                                     -Cpasses=sancov \
+                                     -Cllvm-args=-sanitizer-coverage-level=4 \
+                                     -Cllvm-args=-sanitizer-coverage-trace-compares \
+                                     -Cllvm-args=-sanitizer-coverage-inline-8bit-counters \
+                                     -Cllvm-args=-sanitizer-coverage-trace-geps \
+                                     -Cllvm-args=-sanitizer-coverage-prune-blocks=0 \
+                                     -Cllvm-args=-sanitizer-coverage-pc-table \
+                                     -Clink-dead-code"
+            .to_owned();
+        match build.sanitizer {
+            Sanitizer::None => {}
+            _ => rustflags.push_str(&format!(
+                " -Zsanitizer={sanitizer}",
+                sanitizer = build.sanitizer
+            )),
+        }
         if build.triple.contains("-linux-") {
             rustflags.push_str(" -Cllvm-args=-sanitizer-coverage-stack-depth");
         }


### PR DESCRIPTION
Safe rust should largely not require AddrSan, so instead just build
without any sanitizers and let the fuzzer hunt for panics faster.

This speeds things up by about 2x on one of my targets, and appears to find new interesting targets without any changes.