### PR TITLE
Adds support for `fmt` subcomand for test case debug formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Create a new fuzzing target!
 
 Run a fuzzing target and find bugs!
 
+### `cargo fuzz fmt <target> <input>`
+
+Print debug output for an input test case!
+
 ### `cargo fuzz tmin <target> <input>`
 
 Found a failing input? Minify it to the smallest input that causes that failure

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ enum Command {
     Build(options::Build),
 
     /// Print debugging output for fuzz inputs
-    DebugFmt(options::DebugFmt),
+    Fmt(options::Fmt),
 
     /// List all the existing fuzz targets
     List(options::List),
@@ -125,7 +125,7 @@ impl RunCommand for Command {
             Command::Add(x) => x.run_command(),
             Command::Build(x) => x.run_command(),
             Command::List(x) => x.run_command(),
-            Command::DebugFmt(x) => x.run_command(),
+            Command::Fmt(x) => x.run_command(),
             Command::Run(x) => x.run_command(),
             Command::Cmin(x) => x.run_command(),
             Command::Tmin(x) => x.run_command(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,9 @@ enum Command {
     /// Build fuzz targets
     Build(options::Build),
 
+    /// Print debugging output for fuzz inputs
+    DebugFmt(options::DebugFmt),
+
     /// List all the existing fuzz targets
     List(options::List),
 
@@ -122,6 +125,7 @@ impl RunCommand for Command {
             Command::Add(x) => x.run_command(),
             Command::Build(x) => x.run_command(),
             Command::List(x) => x.run_command(),
+            Command::DebugFmt(x) => x.run_command(),
             Command::Run(x) => x.run_command(),
             Command::Cmin(x) => x.run_command(),
             Command::Tmin(x) => x.run_command(),

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,18 +1,17 @@
 mod add;
 mod build;
 mod cmin;
-mod debugfmt;
+mod fmt;
 mod init;
 mod list;
 mod run;
 mod tmin;
 
 pub use self::{
-    add::Add, build::Build, cmin::Cmin, debugfmt::DebugFmt, init::Init, list::List, run::Run,
-    tmin::Tmin,
+    add::Add, build::Build, cmin::Cmin, fmt::Fmt, init::Init, list::List, run::Run, tmin::Tmin,
 };
 
-use std::fmt;
+use std::fmt as stdfmt;
 use std::str::FromStr;
 use structopt::StructOpt;
 
@@ -25,8 +24,8 @@ pub enum Sanitizer {
     None,
 }
 
-impl fmt::Display for Sanitizer {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl stdfmt::Display for Sanitizer {
+    fn fmt(&self, f: &mut stdfmt::Formatter) -> stdfmt::Result {
         write!(
             f,
             "{}",

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,12 +1,16 @@
 mod add;
 mod build;
 mod cmin;
+mod debugfmt;
 mod init;
 mod list;
 mod run;
 mod tmin;
 
-pub use self::{add::Add, build::Build, cmin::Cmin, init::Init, list::List, run::Run, tmin::Tmin};
+pub use self::{
+    add::Add, build::Build, cmin::Cmin, debugfmt::DebugFmt, init::Init, list::List, run::Run,
+    tmin::Tmin,
+};
 
 use std::fmt;
 use std::str::FromStr;

--- a/src/options/debugfmt.rs
+++ b/src/options/debugfmt.rs
@@ -1,0 +1,26 @@
+use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
+use anyhow::Result;
+use structopt::StructOpt;
+
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct DebugFmt {
+    #[structopt(flatten)]
+    pub build: BuildOptions,
+
+    #[structopt(required = true)]
+    /// Name of fuzz target
+    pub target: String,
+
+    #[structopt(required = true)]
+    /// Path to the input testcase to debug print
+    pub input: PathBuf,
+}
+
+impl RunCommand for DebugFmt {
+    fn run_command(&mut self) -> Result<()> {
+        let project = FuzzProject::find_existing()?;
+        project.debug_fmt_input(self)
+    }
+}

--- a/src/options/fmt.rs
+++ b/src/options/fmt.rs
@@ -5,7 +5,7 @@ use structopt::StructOpt;
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, StructOpt)]
-pub struct DebugFmt {
+pub struct Fmt {
     #[structopt(flatten)]
     pub build: BuildOptions,
 
@@ -18,7 +18,7 @@ pub struct DebugFmt {
     pub input: PathBuf,
 }
 
-impl RunCommand for DebugFmt {
+impl RunCommand for Fmt {
     fn run_command(&mut self) -> Result<()> {
         let project = FuzzProject::find_existing()?;
         project.debug_fmt_input(self)

--- a/src/project.rs
+++ b/src/project.rs
@@ -336,19 +336,26 @@ impl FuzzProject {
     /// Prints the debug output of an input test case
     pub fn debug_fmt_input(&self, debugfmt: &options::Fmt) -> Result<()> {
         if !debugfmt.input.exists() {
-            bail!("Input test case does not exist.");
+            bail!(
+                "Input test case does not exist: {}",
+                debugfmt.input.display()
+            );
         }
 
-        if let Ok(debug) =
-            self.run_fuzz_target_debug_formatter(&debugfmt.build, &debugfmt.target, &debugfmt.input)
-        {
-            eprintln!("Output of `std::fmt::Debug`:\n");
-            for l in debug.lines() {
-                eprintln!("{}", l);
-            }
-        } else {
-            bail!("Unable to return debug-formatted output for input test case.")
+        let debug = self
+            .run_fuzz_target_debug_formatter(&debugfmt.build, &debugfmt.target, &debugfmt.input)
+            .with_context(|| {
+                format!(
+                    "failed to run `cargo fuzz fmt` on input: {}",
+                    debugfmt.input.display()
+                )
+            })?;
+
+        eprintln!("\nOutput of `std::fmt::Debug`:\n");
+        for l in debug.lines() {
+            eprintln!("{}", l);
         }
+
         Ok(())
     }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -334,18 +334,20 @@ impl FuzzProject {
     }
 
     /// Prints the debug output of an input test case
-    pub fn debug_fmt_input(&self, debugfmt: &options::DebugFmt) -> Result<()> {
+    pub fn debug_fmt_input(&self, debugfmt: &options::Fmt) -> Result<()> {
         if !debugfmt.input.exists() {
             bail!("Input test case does not exist.");
         }
-
+        
         if let Ok(debug) =
             self.run_fuzz_target_debug_formatter(&debugfmt.build, &debugfmt.target, &debugfmt.input)
         {
             eprintln!("Output of `std::fmt::Debug`:\n");
             for l in debug.lines() {
-                eprintln!("\t{}", l);
+                eprintln!("{}", l);
             }
+        } else {
+            bail!("Unable to return debug-formatted output for input test case.")
         }
         Ok(())
     }

--- a/src/project.rs
+++ b/src/project.rs
@@ -333,6 +333,23 @@ impl FuzzProject {
         Ok(debug)
     }
 
+    /// Prints the debug output of an input test case
+    pub fn debug_fmt_input(&self, debugfmt: &options::DebugFmt) -> Result<()> {
+        if !debugfmt.input.exists() {
+            bail!("Input test case does not exist.");
+        }
+
+        if let Ok(debug) =
+            self.run_fuzz_target_debug_formatter(&debugfmt.build, &debugfmt.target, &debugfmt.input)
+        {
+            eprintln!("Output of `std::fmt::Debug`:\n");
+            for l in debug.lines() {
+                eprintln!("\t{}", l);
+            }
+        }
+        Ok(())
+    }
+
     /// Fuzz a given fuzz target
     pub fn exec_fuzz(&self, run: &options::Run) -> Result<()> {
         self.exec_build(&run.build, Some(&run.target))?;

--- a/src/project.rs
+++ b/src/project.rs
@@ -338,7 +338,7 @@ impl FuzzProject {
         if !debugfmt.input.exists() {
             bail!("Input test case does not exist.");
         }
-        
+
         if let Ok(debug) =
             self.run_fuzz_target_debug_formatter(&debugfmt.build, &debugfmt.target, &debugfmt.input)
         {

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -427,8 +427,7 @@ fn debug_fmt() {
                     b: u8,
                 }
 
-                impl Arbitrary for Rgb
-                {
+                impl Arbitrary for Rgb {
                     fn arbitrary(raw: &mut Unstructured<'_>) -> Result<Self> {
                         let mut buf = [0; 3];
                         raw.fill_buffer(&mut buf)?;


### PR DESCRIPTION
Adds support for https://github.com/rust-fuzz/cargo-fuzz/issues/220.

Subcommand routine is pretty rudimentary, where it basically checks to see if the test case exists, and then calls `run_fuzz_target_debug_formatter` to properly output the test case (structured input if `arbitrary` is implemented).

Let me know if anything else should be implemented!