### PR TITLE
Remove some LLVM options which excessively slow down code

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -157,8 +157,6 @@ impl FuzzProject {
                                      -Cllvm-args=-sanitizer-coverage-level=4 \
                                      -Cllvm-args=-sanitizer-coverage-trace-compares \
                                      -Cllvm-args=-sanitizer-coverage-inline-8bit-counters \
-                                     -Cllvm-args=-sanitizer-coverage-trace-geps \
-                                     -Cllvm-args=-sanitizer-coverage-prune-blocks=0 \
                                      -Cllvm-args=-sanitizer-coverage-pc-table \
                                      -Clink-dead-code"
             .to_owned();


### PR DESCRIPTION
This commit is a bit of a stab towards #216. I discussed this a bit more
on google/oss-fuzz#3944 and this is intended to sync Rust's `cargo fuzz`
with the default C++ fuzzing there. Apparently the `prune-blocks` and
`trace-geps` options aren't used by libFuzzer and are either
experimental or disable too many optimizations.