### PR TITLE
make Memory Sanitizer actually work

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,5 +16,6 @@ jobs:
       run: |
         rustup install nightly
         rustup default nightly
+        rustup component add rust-src
         export RUST_BACKTRACE=1
         cargo test --verbose

--- a/src/project.rs
+++ b/src/project.rs
@@ -166,6 +166,8 @@ impl FuzzProject {
         match build.sanitizer {
             Sanitizer::None => {}
             Sanitizer::Memory => {
+                // Memory sanitizer requires more flags to function than others:
+                // https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html#memorysanitizer
                 rustflags.push_str(" -Zsanitizer=memory -Zsanitizer-memory-track-origins")
             }
             _ => rustflags.push_str(&format!(

--- a/src/project.rs
+++ b/src/project.rs
@@ -151,6 +151,9 @@ impl FuzzProject {
         for flag in &build.unstable_flags {
             cmd.arg("-Z").arg(flag);
         }
+        if let Sanitizer::Memory = build.sanitizer {
+            cmd.arg("-Z").arg("build-std");
+        }
 
         let mut rustflags: String = "--cfg fuzzing \
                                      -Cpasses=sancov \
@@ -162,6 +165,9 @@ impl FuzzProject {
             .to_owned();
         match build.sanitizer {
             Sanitizer::None => {}
+            Sanitizer::Memory => {
+                rustflags.push_str(" -Zsanitizer=memory -Zsanitizer-memory-track-origins")
+            }
             _ => rustflags.push_str(&format!(
                 " -Zsanitizer={sanitizer}",
                 sanitizer = build.sanitizer

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -306,10 +306,12 @@ fn run_with_msan_no_crash() {
                 use libfuzzer_sys::fuzz_target;
 
                 fuzz_target!(|data: &[u8]| {
-                    let test_data = vec![0,1,2,3];
-                    let accessed_value = test_data[0];
-                    // prevent the read from being optimized out
-                    println!("{}", accessed_value);
+                    // get data from fuzzer and print it
+                    // to force a memory access that cannot be optimized out
+                    let test_data = data.to_owned();
+                    if let Some(x) = data.get(0) {
+                        dbg!(x);
+                    }
                 });
             "#,
         )

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -308,7 +308,6 @@ fn run_with_msan_no_crash() {
                 fuzz_target!(|data: &[u8]| {
                     // get data from fuzzer and print it
                     // to force a memory access that cannot be optimized out
-                    let test_data = data.to_owned();
                     if let Some(x) = data.get(0) {
                         dbg!(x);
                     }

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -296,6 +296,72 @@ fn run_without_sanitizer_with_crash() {
 }
 
 #[test]
+fn run_with_msan_no_crash() {
+    let project = project("run_with_msan_no_crash")
+        .with_fuzz()
+        .fuzz_target(
+            "msan_no_crash",
+            r#"
+                #![no_main]
+                use libfuzzer_sys::fuzz_target;
+
+                fuzz_target!(|data: &[u8]| {
+                    let test_data = vec![0,1,2,3];
+                    let accessed_value = test_data[0];
+                    // prevent the read from being optimized out
+                    println!("{}", accessed_value);
+                });
+            "#,
+        )
+        .build();
+
+    project
+        .cargo_fuzz()
+        .arg("run")
+        .arg("--sanitizer=memory")
+        .arg("msan_no_crash")
+        .arg("--")
+        .arg("-runs=1000")
+        .assert()
+        .stderr(predicate::str::contains("Done 1000 runs"))
+        .success();
+}
+
+#[test]
+fn run_with_msan_with_crash() {
+    let project = project("run_with_msan_with_crash")
+        .with_fuzz()
+        .fuzz_target(
+            "msan_with_crash",
+            r#"
+                #![no_main]
+                use libfuzzer_sys::fuzz_target;
+
+                fuzz_target!(|data: &[u8]| {
+                    let test_data: Vec<u8> = Vec::with_capacity(4);
+                    let uninitialized_value = unsafe {test_data.get_unchecked(0)};
+                    // prevent uninit read from being optimized out
+                    println!("{}", uninitialized_value);
+                });
+            "#,
+        )
+        .build();
+
+    project
+        .cargo_fuzz()
+        .arg("run")
+        .arg("--sanitizer=memory")
+        .arg("msan_with_crash")
+        .arg("--")
+        .arg("-runs=1000")
+        .assert()
+        .stderr(predicate::str::contains(
+            "MemorySanitizer: use-of-uninitialized-value",
+        ))
+        .failure();
+}
+
+#[test]
 fn run_one_input() {
     let corpus = Path::new("fuzz").join("corpus").join("run_one");
 


### PR DESCRIPTION
Use -Zbuild-std and -Zsanitizer-memory-track-origins when Memory Sanitizer is requested. This makes MSAN actually useful instead of making it segfault immediately for any target. Rust documentation clearly states that these flags are required: https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html#memorysanitizer

Tested on `image-png` fuzz target. It segfaulted on startup prior to this change with `-s memory` enabled and works fine now.

This may still fail in presence of C code linked into the binary, but it's a start.