### PR TITLE
Include build options with recommended reproduction command

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -15,7 +15,7 @@ use std::fmt as stdfmt;
 use std::str::FromStr;
 use structopt::StructOpt;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Sanitizer {
     Address,
     Leak,
@@ -109,4 +109,50 @@ pub struct BuildOptions {
     #[structopt(short = "Z", value_name = "FLAG")]
     /// Unstable (nightly-only) flags to Cargo
     pub unstable_flags: Vec<String>,
+}
+
+impl stdfmt::Display for BuildOptions {
+    fn fmt(&self, f: &mut stdfmt::Formatter) -> stdfmt::Result {
+        if self.dev {
+            write!(f, " -D")?;
+        }
+
+        if self.release {
+            write!(f, " -O")?;
+        }
+
+        if self.debug_assertions {
+            write!(f, " -a")?;
+        }
+
+        if self.verbose {
+            write!(f, " -v")?;
+        }
+
+        if self.no_default_features {
+            write!(f, " --no-default-features")?;
+        }
+
+        if self.all_features {
+            write!(f, " --all-features")?;
+        }
+
+        if let Some(feature) = &self.features {
+            write!(f, " --feature={}", feature)?;
+        }
+
+        if self.sanitizer != Sanitizer::None {
+            write!(f, " --sanitizer={}", self.sanitizer)?;
+        }
+
+        if self.triple != crate::utils::default_target() {
+            write!(f, " --target={}", self.triple)?;
+        }
+
+        if !self.unstable_flags.is_empty() {
+            write!(f, " -Z '{}'", self.unstable_flags.join(" "))?;
+        }
+
+        Ok(())
+    }
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -433,12 +433,14 @@ impl FuzzProject {
             }
 
             eprintln!(
-                "Reproduce with:\n\n\tcargo fuzz run {target} {artifact}\n",
+                "Reproduce with:\n\n\tcargo fuzz run{options} {target} {artifact}\n",
+                options = &run.build,
                 target = &run.target,
                 artifact = artifact.display()
             );
             eprintln!(
-                "Minimize test case with:\n\n\tcargo fuzz tmin {target} {artifact}\n",
+                "Minimize test case with:\n\n\tcargo fuzz tmin{options} {target} {artifact}\n",
+                options = &run.build,
                 target = &run.target,
                 artifact = artifact.display()
             );

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -361,12 +361,12 @@ fn run_with_msan_with_crash() {
                 .and(predicate::str::contains(
                     "Reproduce with:\n\
                 \n\
-                \tcargo fuzz run --sanitizer-memory fuzz/artifacts/msan_with_crash/crash-",
+                \tcargo fuzz run --sanitizer=memory msan_with_crash fuzz/artifacts/msan_with_crash/crash-",
                 ))
                 .and(predicate::str::contains(
                     "Minimize test case with:\n\
                 \n\
-                \tcargo fuzz tmin --sanitizer-memory fuzz/artifacts/msan_with_crash/crash-",
+                \tcargo fuzz tmin --sanitizer=memory msan_with_crash fuzz/artifacts/msan_with_crash/crash-",
                 )),
         )
         .failure();

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -356,9 +356,19 @@ fn run_with_msan_with_crash() {
         .arg("--")
         .arg("-runs=1000")
         .assert()
-        .stderr(predicate::str::contains(
-            "MemorySanitizer: use-of-uninitialized-value",
-        ))
+        .stderr(
+            predicate::str::contains("MemorySanitizer: use-of-uninitialized-value")
+                .and(predicate::str::contains(
+                    "Reproduce with:\n\
+                \n\
+                \tcargo fuzz run --sanitizer-memory fuzz/artifacts/msan_with_crash/crash-",
+                ))
+                .and(predicate::str::contains(
+                    "Minimize test case with:\n\
+                \n\
+                \tcargo fuzz tmin --sanitizer-memory fuzz/artifacts/msan_with_crash/crash-",
+                )),
+        )
         .failure();
 }
 


### PR DESCRIPTION
Manually implementing `Display` for `BuildOptions` admittedly doesn't seem like the cleanest way of accomplishing this at first, but I think this is probably more maintainable than trying to write some sort of macro that interfaces with `StructOpt` to see what things are defaults and what the flags are.

Downsides are that if `BuildOptions` are ever changed, the change will have to be added to the `BuildOptions.fmt(Formatter)` function. If that does ever happen the unit test should catch it though.

The bit about the toolchain is contained to one commit at the end so it's easy to remove, should the decision be that we don't want it there.

Closes #228 