### PR TITLE
Support passing --target-dir to cargo build.

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -109,6 +109,10 @@ pub struct BuildOptions {
     #[structopt(short = "Z", value_name = "FLAG")]
     /// Unstable (nightly-only) flags to Cargo
     pub unstable_flags: Vec<String>,
+
+    #[structopt(long = "target-dir")]
+    /// Target dir option to pass to cargo build.
+    pub target_dir: Option<String>,
 }
 
 impl stdfmt::Display for BuildOptions {
@@ -155,6 +159,10 @@ impl stdfmt::Display for BuildOptions {
             write!(f, " -Z{}", flag)?;
         }
 
+        if let Some(target_dir) = &self.target_dir {
+            write!(f, " --target-dir={}", target_dir)?;
+        }
+
         Ok(())
     }
 }
@@ -176,6 +184,7 @@ mod test {
             sanitizer: Sanitizer::Address,
             triple: String::from(crate::utils::default_target()),
             unstable_flags: Vec::new(),
+            target_dir: None,
         };
 
         let opts = vec![
@@ -218,6 +227,10 @@ mod test {
             },
             BuildOptions {
                 unstable_flags: vec![String::from("unstable"), String::from("flags")],
+                ..default_opts.clone()
+            },
+            BuildOptions {
+                target_dir: Some(String::from("/tmp/test")),
                 ..default_opts
             },
         ];

--- a/src/project.rs
+++ b/src/project.rs
@@ -233,6 +233,10 @@ impl FuzzProject {
         let mut cmd = self.cargo("run", build)?;
         cmd.arg("--bin").arg(fuzz_target);
 
+        if let Some(target_dir) = &build.target_dir {
+            cmd.arg("--target-dir").arg(target_dir);
+        }
+
         let mut artifact_arg = ffi::OsString::from("-artifact_prefix=");
         artifact_arg.push(self.artifacts_for(&fuzz_target)?);
         cmd.arg("--").arg(artifact_arg);
@@ -251,6 +255,10 @@ impl FuzzProject {
             cmd.arg("--bin").arg(fuzz_target);
         } else {
             cmd.arg("--bins");
+        }
+
+        if let Some(target_dir) = &build.target_dir {
+            cmd.arg("--target-dir").arg(target_dir);
         }
 
         let status = cmd


### PR DESCRIPTION
This is needed for projects that need --target-dir to be set to a
non-empty value to build properly.