### PR TITLE
Add support for aarch64-apple-darwin.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,10 @@
 /// The default target to pass to cargo, to workaround issue #11.
-#[cfg(target_os = "macos")]
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+pub fn default_target() -> &'static str {
+    "aarch64-apple-darwin"
+}
+
+#[cfg(all(not(target_arch = "aarch64"), target_os = "macos"))]
 pub fn default_target() -> &'static str {
     "x86_64-apple-darwin"
 }


### PR DESCRIPTION
Confirmed `cargo-fuzz` works on my Macbook Air M1 with this change.