### PR TITLE
Allow passing extra arguments to tmin/cmin

### DIFF
--- a/src/options/cmin.rs
+++ b/src/options/cmin.rs
@@ -15,6 +15,10 @@ pub struct Cmin {
     #[structopt(parse(from_os_str))]
     /// The corpus directory to minify into
     pub corpus: Option<PathBuf>,
+
+    #[structopt(last(true))]
+    /// Additional libFuzzer arguments passed through to the binary
+    pub args: Vec<String>,
 }
 
 impl RunCommand for Cmin {

--- a/src/options/tmin.rs
+++ b/src/options/tmin.rs
@@ -28,6 +28,10 @@ pub struct Tmin {
     #[structopt(parse(from_os_str))]
     /// Path to the failing test case to be minimized
     pub test_case: PathBuf,
+
+    #[structopt(last(true))]
+    /// Additional libFuzzer arguments passed through to the binary
+    pub args: Vec<String>,
 }
 
 impl RunCommand for Tmin {

--- a/src/project.rs
+++ b/src/project.rs
@@ -465,6 +465,10 @@ impl FuzzProject {
             .arg(format!("-runs={}", tmin.runs))
             .arg(&tmin.test_case);
 
+        for arg in &tmin.args {
+            cmd.arg(arg);
+        }
+
         let before_tmin = time::SystemTime::now();
 
         let mut child = cmd
@@ -532,6 +536,10 @@ impl FuzzProject {
     pub fn exec_cmin(&self, cmin: &options::Cmin) -> Result<()> {
         self.exec_build(&cmin.build, Some(&cmin.target))?;
         let mut cmd = self.cargo_run(&cmin.build, &cmin.target)?;
+
+        for arg in &cmin.args {
+            cmd.arg(arg);
+        }
 
         let corpus = if let Some(corpus) = cmin.corpus.clone() {
             corpus


### PR DESCRIPTION
I noticed I needed to pass `-detect_leaks=0 -rss_limit_mb=8192` to `run`, but the CLI didn't allow passing those to `cmin` or `tmin`. So I changed that, and now cmin/tmin seem to do something.