### PR TITLE
Relax fuzz dir name constraint

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -13,8 +13,8 @@ pub use self::{
     run::Run, tmin::Tmin,
 };
 
-use std::fmt as stdfmt;
 use std::str::FromStr;
+use std::{fmt as stdfmt, path::PathBuf};
 use structopt::StructOpt;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -180,6 +180,23 @@ impl stdfmt::Display for BuildOptions {
 
         if self.coverage {
             write!(f, " --coverage")?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, StructOpt, PartialEq)]
+pub struct FuzzDirWrapper {
+    /// The path to the fuzz project directory.
+    #[structopt(long = "fuzz-dir")]
+    pub fuzz_dir: Option<PathBuf>,
+}
+
+impl stdfmt::Display for FuzzDirWrapper {
+    fn fmt(&self, f: &mut stdfmt::Formatter) -> stdfmt::Result {
+        if let Some(ref elem) = self.fuzz_dir {
+            write!(f, " --fuzz-dir={}", elem.display())?;
         }
 
         Ok(())

--- a/src/options/add.rs
+++ b/src/options/add.rs
@@ -1,16 +1,19 @@
-use crate::{project::FuzzProject, RunCommand};
+use crate::{options::FuzzDirWrapper, project::FuzzProject, RunCommand};
 use anyhow::Result;
 use structopt::StructOpt;
 
 #[derive(Clone, Debug, StructOpt)]
 pub struct Add {
+    #[structopt(flatten)]
+    pub fuzz_dir_wrapper: FuzzDirWrapper,
+
     /// Name of the new fuzz target
     pub target: String,
 }
 
 impl RunCommand for Add {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::find_existing()?;
+        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
         project.add_target(self)
     }
 }

--- a/src/options/build.rs
+++ b/src/options/build.rs
@@ -1,4 +1,8 @@
-use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
+use crate::{
+    options::{BuildOptions, FuzzDirWrapper},
+    project::FuzzProject,
+    RunCommand,
+};
 use anyhow::Result;
 use structopt::StructOpt;
 
@@ -7,13 +11,16 @@ pub struct Build {
     #[structopt(flatten)]
     pub build: BuildOptions,
 
+    #[structopt(flatten)]
+    pub fuzz_dir_wrapper: FuzzDirWrapper,
+
     /// Name of the fuzz target to build, or build all targets if not supplied
     pub target: Option<String>,
 }
 
 impl RunCommand for Build {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::find_existing()?;
+        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
         project.exec_build(&self.build, self.target.as_deref().map(|s| s))
     }
 }

--- a/src/options/cmin.rs
+++ b/src/options/cmin.rs
@@ -1,4 +1,8 @@
-use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
+use crate::{
+    options::{BuildOptions, FuzzDirWrapper},
+    project::FuzzProject,
+    RunCommand,
+};
 use anyhow::Result;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -7,6 +11,9 @@ use structopt::StructOpt;
 pub struct Cmin {
     #[structopt(flatten)]
     pub build: BuildOptions,
+
+    #[structopt(flatten)]
+    pub fuzz_dir_wrapper: FuzzDirWrapper,
 
     /// Name of the fuzz target
     pub target: String,
@@ -22,7 +29,7 @@ pub struct Cmin {
 
 impl RunCommand for Cmin {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::find_existing()?;
+        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
         project.exec_cmin(self)
     }
 }

--- a/src/options/coverage.rs
+++ b/src/options/coverage.rs
@@ -1,4 +1,8 @@
-use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
+use crate::{
+    options::{BuildOptions, FuzzDirWrapper},
+    project::FuzzProject,
+    RunCommand,
+};
 use anyhow::Result;
 use structopt::StructOpt;
 
@@ -6,6 +10,9 @@ use structopt::StructOpt;
 pub struct Coverage {
     #[structopt(flatten)]
     pub build: BuildOptions,
+
+    #[structopt(flatten)]
+    pub fuzz_dir_wrapper: FuzzDirWrapper,
 
     /// Name of the fuzz target
     pub target: String,
@@ -20,7 +27,7 @@ pub struct Coverage {
 
 impl RunCommand for Coverage {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::find_existing()?;
+        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
         self.build.coverage = true;
         project.exec_coverage(self)
     }

--- a/src/options/fmt.rs
+++ b/src/options/fmt.rs
@@ -1,4 +1,8 @@
-use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
+use crate::{
+    options::{BuildOptions, FuzzDirWrapper},
+    project::FuzzProject,
+    RunCommand,
+};
 use anyhow::Result;
 use structopt::StructOpt;
 
@@ -9,6 +13,9 @@ pub struct Fmt {
     #[structopt(flatten)]
     pub build: BuildOptions,
 
+    #[structopt(flatten)]
+    pub fuzz_dir_wrapper: FuzzDirWrapper,
+
     /// Name of fuzz target
     pub target: String,
 
@@ -18,7 +25,7 @@ pub struct Fmt {
 
 impl RunCommand for Fmt {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::find_existing()?;
+        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
         project.debug_fmt_input(self)
     }
 }

--- a/src/options/init.rs
+++ b/src/options/init.rs
@@ -1,4 +1,4 @@
-use crate::{project::FuzzProject, RunCommand};
+use crate::{options::FuzzDirWrapper, project::FuzzProject, RunCommand};
 use anyhow::Result;
 use structopt::StructOpt;
 
@@ -12,11 +12,14 @@ pub struct Init {
     )]
     /// Name of the first fuzz target to create
     pub target: String,
+
+    #[structopt(flatten)]
+    pub fuzz_dir_wrapper: FuzzDirWrapper,
 }
 
 impl RunCommand for Init {
     fn run_command(&mut self) -> Result<()> {
-        FuzzProject::init(self)?;
+        FuzzProject::init(self, self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
         Ok(())
     }
 }

--- a/src/options/list.rs
+++ b/src/options/list.rs
@@ -1,13 +1,16 @@
-use crate::{project::FuzzProject, RunCommand};
+use crate::{options::FuzzDirWrapper, project::FuzzProject, RunCommand};
 use anyhow::Result;
 use structopt::StructOpt;
 
 #[derive(Clone, Debug, StructOpt)]
-pub struct List {}
+pub struct List {
+    #[structopt(flatten)]
+    pub fuzz_dir_wrapper: FuzzDirWrapper,
+}
 
 impl RunCommand for List {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::find_existing()?;
+        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
         project.list_targets()
     }
 }

--- a/src/options/run.rs
+++ b/src/options/run.rs
@@ -1,4 +1,8 @@
-use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
+use crate::{
+    options::{BuildOptions, FuzzDirWrapper},
+    project::FuzzProject,
+    RunCommand,
+};
 use anyhow::Result;
 use structopt::StructOpt;
 
@@ -12,6 +16,9 @@ pub struct Run {
 
     /// Custom corpus directories or artifact files.
     pub corpus: Vec<String>,
+
+    #[structopt(flatten)]
+    pub fuzz_dir_wrapper: FuzzDirWrapper,
 
     #[structopt(
         short = "j",
@@ -33,7 +40,7 @@ pub struct Run {
 
 impl RunCommand for Run {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::find_existing()?;
+        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
         project.exec_fuzz(self)
     }
 }

--- a/src/options/tmin.rs
+++ b/src/options/tmin.rs
@@ -1,4 +1,8 @@
-use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
+use crate::{
+    options::{BuildOptions, FuzzDirWrapper},
+    project::FuzzProject,
+    RunCommand,
+};
 use anyhow::Result;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -7,6 +11,9 @@ use structopt::StructOpt;
 pub struct Tmin {
     #[structopt(flatten)]
     pub build: BuildOptions,
+
+    #[structopt(flatten)]
+    pub fuzz_dir_wrapper: FuzzDirWrapper,
 
     /// Name of the fuzz target
     pub target: String,
@@ -35,7 +42,7 @@ pub struct Tmin {
 
 impl RunCommand for Tmin {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::find_existing()?;
+        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
         project.exec_tmin(self)
     }
 }


### PR DESCRIPTION
Fixes #238 

I am not fully aware of the internals of this project and the chosen approach might not be the best. But hey, it is working.

```bash
cargo fuzz run --fuzz-dir some_fuzz_project_dir someTarget
```