### PR TITLE
Remove leading newlines from Cargo.toml and .gitignore

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,8 +1,7 @@
 macro_rules! toml_template {
     ($name: expr) => {
         format_args!(
-            r##"
-[package]
+            r##"[package]
 name = "{0}-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
@@ -45,8 +44,7 @@ doc = false
 macro_rules! gitignore_template {
     () => {
         format_args!(
-            r##"
-target
+            r##"target
 corpus
 artifacts
 "##


### PR DESCRIPTION
Looking at several projects where `cargo fuzz` was
integrated (like https://github.com/unicode-rs/unicode-normalization/commit/387bcb64745e76a59f8c0e8aa4e7465107369c11)
I think everybody seems to remove the leading newlines manually so
it appears they shouldn't have been generated with `cargo init`
in the first place.