### PR TITLE
Don't hardcode target strings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+use std::env;
+
+fn main() {
+    println!("cargo:rustc-env=TARGET={}", env::var("TARGET").unwrap());
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,16 +1,4 @@
 /// The default target to pass to cargo, to workaround issue #11.
-#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 pub fn default_target() -> &'static str {
-    "aarch64-apple-darwin"
-}
-
-#[cfg(all(not(target_arch = "aarch64"), target_os = "macos"))]
-pub fn default_target() -> &'static str {
-    "x86_64-apple-darwin"
-}
-
-/// The default target to pass to cargo, to workaround issue #11.
-#[cfg(not(target_os = "macos"))]
-pub fn default_target() -> &'static str {
-    "x86_64-unknown-linux-gnu"
+    env!("TARGET")
 }


### PR DESCRIPTION
This should help get `cargo fuzz` working on other systems, such as
aarch64-unknown-linux-gnu, without having to always pass `--target`