### PR TITLE
Adjust for NewPM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,19 +5,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Check rustfmt
-      run: |
-        rustup component add rustfmt --toolchain stable
-        cargo +stable fmt --all -- --check
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: |
-        rustup install nightly
-        rustup default nightly
-        rustup component add rust-src
-        rustup component add llvm-tools-preview
-        cargo install cargo-binutils
-        export RUST_BACKTRACE=1
-        cargo test --verbose
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly
+          profile: minimal
+          default: true
+          components: rustfmt, rust-src, llvm-tools-preview
+    - uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+    - uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: cargo-binutils
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --verbose
+      env:
+        RUST_BACKTRACE: 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fuzz"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-fuzz"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["The rust-fuzz Project Developers"]
 license = "MIT OR Apache-2.0"
 description = "A `cargo` subcommand for fuzzing with `libFuzzer`! Easy to use!"

--- a/src/project.rs
+++ b/src/project.rs
@@ -159,7 +159,7 @@ impl FuzzProject {
             cmd.arg("-Z").arg("build-std");
         }
 
-        let mut rustflags: String = "-Cpasses=sancov \
+        let mut rustflags: String = "-Cpasses=sancov-module \
                                      -Cllvm-args=-sanitizer-coverage-level=4 \
                                      -Cllvm-args=-sanitizer-coverage-trace-compares \
                                      -Cllvm-args=-sanitizer-coverage-inline-8bit-counters \


### PR DESCRIPTION
This is necessary to work with the most recent rust nightlies. As a
downside, cargo-fuzz will stop working with the older versions of
nightly...

Fixes #276