### PR TITLE
Include the fuzzer entrypoint on Windows

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -196,6 +196,10 @@ impl FuzzProject {
         if !build.release || build.debug_assertions {
             rustflags.push_str(" -Cdebug-assertions");
         }
+        if build.triple.contains("-msvc") {
+            // The entrypoint is in the bundled libfuzzer rlib, this gets the linker to find it.
+            rustflags.push_str(" -Clink-arg=/include:main");
+        }
 
         // If release mode is enabled then we force 1 CGU to be used in rustc.
         // This will result in slower compilations but it looks like the sancov


### PR DESCRIPTION
The current entrypoint for fuzzing ends up in a bundled static library in an rlib.

This change tells the linker to include main, which will then cause the entrypoint to be found and included from the rlib.

Note that this also requires a change on the rust side https://github.com/rust-lang/rust/pull/89369 to enable sanitizer support.