### PR TITLE
Enable Running Test Cases on Windows 

### DIFF
--- a/tests/tests/project.rs
+++ b/tests/tests/project.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+use toml;
 
 pub fn target_tests() -> PathBuf {
     let mut path = env::current_exe().unwrap();
@@ -107,12 +108,12 @@ impl ProjectBuilder {
             r#"
                 [[bin]]
                 name = "{name}"
-                path = "{path}"
+                path = {path}
                 test = false
                 doc = false
             "#,
             name = name,
-            path = path.display(),
+            path = toml::to_string(&path).unwrap(),
         )
         .unwrap();
 


### PR DESCRIPTION
#279 includes changes necessary to start supporting Windows once support also lands in `rustc` (see https://github.com/rust-lang/rust/pull/89369). I wanted to explore the current state of support by running the `cargo-fuzz` test suite with the `rust` toolchain built with Windows support for `asan` symbols enabled. I've run in to two issues so far.

###  First Issue - Addressed

The test suite generates a set of fuzz targets and associated `Cargo.toml` manifest files. Those files include path configuration that, up until this point, has leveraged the `PathBuf` display functionality to render the paths as strings for the generated `toml` file. This breaks on Windows. `toml` needs `\` in Windows paths to be escaped, which display does not do. Using the `toml` serializer address this in a cross platform way. I have tested this change on Windows and Linux. While I don't have a Mac system to test on I have no reason to think this is a risky change there.

### Second Issue - Work In Progress

With a dev toolchain built and linked including the changes from https://github.com/rust-lang/rust/pull/89369 and the above path issue addressed there are still failures of the test cases on Windows. All test cases that execute fuzz tests fail with:

```
error: unable to unlink old fallback exe: Access is denied. (os error 5)
```

References to this error I've found suggest it has to do with calling `cargo` from within another execution of `cargo` on Windows, which is the behavior we're attempting in these test cases. Reference https://github.com/rust-lang/rust-clippy/issues/3118. Clippy addressed this with hardcoding the `+nightly` toolchain in their calls to `cargo` which might work here when/if https://github.com/rust-lang/rust/pull/89369 or other support hits nightly. I'm investigating other options.