### PR TITLE
add coverage dir to .gitignore

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -47,6 +47,7 @@ macro_rules! gitignore_template {
             r##"target
 corpus
 artifacts
+coverage
 "##
         )
     };


### PR DESCRIPTION
I found the coverage directory is not in `.gitignore` when I try to generate coverage report for my fuzz target.