### PR TITLE
Add --no-trace-compares flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Released YYYY-MM-DD.
 * Added the `--no-trace-compares` flag which opts out of the
   `-sanitizer-coverage-trace-compares` LLVM argument.
 
-  Using this may improve performance at the cost of worse fuzzing accuracy.
-  It also allows older CPUs lacking the `popcnt` instruction to use cargo-fuzz;
+  Using this may improve fuzzer throughput at the cost of worse coverage accuracy.
+  It also allows older CPUs lacking the `popcnt` instruction to use `cargo-fuzz`;
   the `*-trace-compares` instrumentation assumes that the instruction is
   available.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ Released YYYY-MM-DD.
 
 ### Added
 
-* TODO (or remove section if none)
+* Added the `--no-trace-compares` flag which opts out of the
+  `-sanitizer-coverage-trace-compares` LLVM argument.
+
+  Using this may improve performance at the cost of worse fuzzing accuracy.
+  It also allows older CPUs lacking the `popcnt` instruction to use cargo-fuzz;
+  the `*-trace-compares` instrumentation assumes that the instruction is
+  available.
 
 ### Changed
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -133,6 +133,10 @@ pub struct BuildOptions {
     /// allows you to opt out of it.
     #[structopt(long)]
     pub no_cfg_fuzzing: bool,
+
+    #[structopt(long)]
+    /// Don't build with the `sanitizer-coverage-trace-compares` LLVM argument
+    pub no_trace_compares: bool,
 }
 
 impl stdfmt::Display for BuildOptions {
@@ -229,6 +233,7 @@ mod test {
             coverage: false,
             strip_dead_code: false,
             no_cfg_fuzzing: false,
+            no_trace_compares: false,
         };
 
         let opts = vec![

--- a/src/options.rs
+++ b/src/options.rs
@@ -136,6 +136,11 @@ pub struct BuildOptions {
 
     #[structopt(long)]
     /// Don't build with the `sanitizer-coverage-trace-compares` LLVM argument
+    ///
+    ///  Using this may improve fuzzer throughput at the cost of worse coverage accuracy.
+    /// It also allows older CPUs lacking the `popcnt` instruction to use `cargo-fuzz`;
+    /// the `*-trace-compares` instrumentation assumes that the instruction is
+    /// available.
     pub no_trace_compares: bool,
 }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -161,10 +161,13 @@ impl FuzzProject {
 
         let mut rustflags: String = "-Cpasses=sancov-module \
                                      -Cllvm-args=-sanitizer-coverage-level=4 \
-                                     -Cllvm-args=-sanitizer-coverage-trace-compares \
                                      -Cllvm-args=-sanitizer-coverage-inline-8bit-counters \
                                      -Cllvm-args=-sanitizer-coverage-pc-table"
             .to_owned();
+
+        if !build.no_trace_compares {
+            rustflags.push_str(" -Cllvm-args=-sanitizer-coverage-trace-compares");
+        }
 
         if !build.no_cfg_fuzzing {
             rustflags.push_str(" --cfg fuzzing");


### PR DESCRIPTION
The flag will opt-out of the `-sanitizer-coverage-trace-compares` LLVM flag that cargo-fuzz builds with by default. The LLVM flag can help with fuzzing but it's not without overhead so disabling it can improve performance. It also allows older CPUs without the `popcnt` instruction to run the binaries built by cargo-fuzz since the `trace-compares` instrumentation requires it.

Fixes #287.