### PR TITLE
Add a flag to toggle -Zbuild-std, and default to using it

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -82,6 +82,14 @@ pub struct BuildOptions {
     /// Use a specific sanitizer
     pub sanitizer: Sanitizer,
 
+    #[arg(long = "build-std")]
+    /// Pass -Zbuild-std to Cargo, which will build the standard library with all the build
+    /// settings for the fuzz target, including debug assertions, and a sanitizer if requested.
+    /// Currently this conflicts with coverage instrumentation but -Zbuild-std enables detecting
+    /// more bugs so this option defaults to true, but when using `cargo fuzz coverage` it
+    /// defaults to false.
+    pub build_std: Option<bool>,
+
     #[arg(long = "target", default_value(crate::utils::default_target()))]
     /// Target triple of the fuzz target
     pub triple: String,
@@ -209,6 +217,7 @@ mod test {
             no_default_features: false,
             all_features: false,
             features: None,
+            build_std: None,
             sanitizer: Sanitizer::Address,
             triple: String::from(crate::utils::default_target()),
             unstable_flags: Vec::new(),

--- a/src/options/coverage.rs
+++ b/src/options/coverage.rs
@@ -3,7 +3,7 @@ use crate::{
     project::FuzzProject,
     RunCommand,
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::Parser;
 
 #[derive(Clone, Debug, Parser)]
@@ -27,6 +27,12 @@ pub struct Coverage {
 
 impl RunCommand for Coverage {
     fn run_command(&mut self) -> Result<()> {
+        if self.build.build_std.unwrap_or(false) {
+            bail!(
+                "-Zbuild-std is currently incompatible with -Zinstrument-coverage, \
+                see https://github.com/rust-lang/wg-cargo-std-aware/issues/63"
+            );
+        }
         let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
         self.build.coverage = true;
         project.exec_coverage(self)

--- a/src/project.rs
+++ b/src/project.rs
@@ -158,6 +158,8 @@ impl FuzzProject {
         }
         if let Sanitizer::Memory = build.sanitizer {
             cmd.arg("-Z").arg("build-std");
+        } else if build.build_std.unwrap_or(true) && !build.coverage {
+            cmd.arg("-Z").arg("build-std");
         }
 
         let mut rustflags: String = "-Cpasses=sancov-module \


### PR DESCRIPTION
By default, all the debug assertions in the standard library are compiled out, and the only way to get them back is `-Zbuild-std`.

Even generic debug assertions can catch code that passes the sanitizers. For example, in this PR I'm trying to add more and I found a few bugs in the compiler by doing so: https://github.com/rust-lang/rust/pull/92686

Having these assertions on _in general_ is also a very good idea, because even if the behavior would be caught eventually, catching it at the source is an aid to debugging. Example here: https://reddit.com/r/rust/comments/t87itu/how_can_i_debugreport_possible_compiler_bugs/

Turning on `-Zbuild-std` with debug assertions enabled introduces a performance regression. I'm trying to squint at a bunch of numbers over here, but things keep shifting around. Maybe I'm just bad at this. My best guess is that turning on `-Zbuild-std` is a ~20% regression. Still much better than just turning on ASan, which is a ~60% regression.

I'm also a big fan of having these on by default because these debug assertions work everywhere and with all codebases, as opposed to tools like ASan which doesn't necessarily.