### PR TITLE
Align arch support to the fuzz book

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@
 $ cargo install cargo-fuzz
 ```
 
-Note: `libFuzzer` needs LLVM sanitizer support, so this only works on x86-64
-Linux and x86-64 macOS for now. This also needs a nightly Rust toolchain since
-it uses some unstable command-line flags. Finally, you'll also need a C++
-compiler with C++11 support.
+Note: `libFuzzer` needs LLVM sanitizer support, so this only works on x86-64 Linux, x86-64 macOS
+and Apple-Silicon (aarch64) macOS for now. This also needs a nightly compiler since it uses some
+unstable command-line flags. You'll also need a C++ compiler with C++11 support.
 
 If you have an old version of `cargo fuzz`, you can upgrade with this command:
 


### PR DESCRIPTION
I am on apple silicon and was disappointed to read I won't be able
to use it then until I saw the book said differently. I then tried and it
worked, so the book is correct :)

See https://github.com/rust-fuzz/book/commit/4652b209e8f403e9075c0f57a17fd8d0bc4a0aed