### PR TITLE
Switch `-Zinstrument-coverage` to `-C`

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -178,7 +178,7 @@ impl FuzzProject {
         }
 
         if build.coverage {
-            rustflags.push_str(" -Zinstrument-coverage");
+            rustflags.push_str(" -Cinstrument-coverage");
         }
 
         match build.sanitizer {


### PR DESCRIPTION
This is a stable option now so it can use `-C` to prevent a warning from
being emitted from rustc