### PR TITLE
Update the URL for coverage tools installation

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -706,7 +706,7 @@ impl FuzzProject {
             .with_context(|| "Merging raw coverage files failed.\n\
                               \n\
                               Do you have LLVM coverage tools installed?\n\
-                              https://doc.rust-lang.org/beta/unstable-book/compiler-flags/source-based-code-coverage.html#installing-llvm-coverage-tools")?;
+                              https://doc.rust-lang.org/rustc/instrument-coverage.html#installing-llvm-coverage-tools")?;
         if !status.success() {
             Err(anyhow!(
                 "Command exited with failure status {}: {:?}",


### PR DESCRIPTION
The current link 404s because the source-based coverage has been stabilized.