### PR TITLE
Remove `authors = ["Automatically generated"]` from template

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -4,7 +4,6 @@ macro_rules! toml_template {
             r##"[package]
 name = "{0}-fuzz"
 version = "0.0.0"
-authors = ["Automatically generated"]
 publish = false
 edition = "2018"
 

--- a/tests/tests/project.rs
+++ b/tests/tests/project.rs
@@ -73,7 +73,6 @@ impl ProjectBuilder {
                     [package]
                     name = "{name}-fuzz"
                     version = "0.0.0"
-                    authors = ["Automatically generated"]
                     publish = false
                     edition = "2018"
 


### PR DESCRIPTION
The `authors` field in Cargo.toml has always been optional, ever since the Cargo in the 1.0.0 toolchain.

Including `authors = ["Automatically generated"]` seems pretty pointless, especially as the intention is that user won't keep the generated fuzz_target_1.rs but make their own (non-generated) changes.

Manifests generated by `cargo new` and `cargo init` do not include an `authors` field since 1.53.0 and I think `cargo fuzz init` shouldn't either.