### PR TITLE
Copy edition from root project

### DIFF
--- a/src/options/add.rs
+++ b/src/options/add.rs
@@ -1,4 +1,5 @@
-use crate::{options::FuzzDirWrapper, project::FuzzProject, RunCommand};
+use crate::project::{FuzzProject, Manifest};
+use crate::{options::FuzzDirWrapper, RunCommand};
 use anyhow::Result;
 use structopt::StructOpt;
 
@@ -14,6 +15,8 @@ pub struct Add {
 impl RunCommand for Add {
     fn run_command(&mut self) -> Result<()> {
         let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
-        project.add_target(self)
+        let fuzz_manifest_path = project.fuzz_dir().join("Cargo.toml");
+        let manifest = Manifest::parse(&fuzz_manifest_path)?;
+        project.add_target(self, &manifest)
     }
 }

--- a/tests/tests/project.rs
+++ b/tests/tests/project.rs
@@ -74,7 +74,7 @@ impl ProjectBuilder {
                     name = "{name}-fuzz"
                     version = "0.0.0"
                     publish = false
-                    edition = "2018"
+                    edition = "2021"
 
                     [package.metadata]
                     cargo-fuzz = true


### PR DESCRIPTION
Previously `cargo fuzz init` would always emit edition=2018 manifests, even if the root project was on 2015 or 2021. This PR makes it initialize the fuzz targets' manifest using the same edition that the root project is using.