### PR TITLE
"disable all instrumentation" flag

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -100,6 +100,10 @@ pub struct BuildOptions {
     /// Use a specific sanitizer
     pub sanitizer: Sanitizer,
 
+    #[structopt(long = "disable-instrumentation")]
+    /// Disable all sanitizers and coverage instrumentation
+    pub disable_instrumentation: bool,
+
     #[structopt(
         name = "triple",
         long = "target",
@@ -239,6 +243,7 @@ mod test {
             strip_dead_code: false,
             no_cfg_fuzzing: false,
             no_trace_compares: false,
+            disable_instrumentation: false,
         };
 
         let opts = vec![


### PR DESCRIPTION
Some analysis engines such as the symbolic execution analysis in [Mayhem](https://forallsecure.com/mayhem-for-code) can only work on binaries that are _not_ instrumented with code coverage or sanitizers. Rust flags such as `-Cpasses=sancov-module` are not exposed in a commandline flag yet, but I needed to disable it, among others.

I created a _--disable-instrumentation_ CLI flag that disables sancov and all sanitizers. It might be useful for the help text to say something like "only enable this if you know what you're doing", but running the compiled harness also emits warnings of its own and exits, so there is no risk of someone accidentally using the flag and thinking that fuzzing is working.

```
WARNING: Failed to find function "__sanitizer_acquire_crash_state".
WARNING: Failed to find function "__sanitizer_print_stack_trace".
WARNING: Failed to find function "__sanitizer_set_death_callback".
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 4270720352
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: A corpus is not provided, starting from an empty corpus
#2	INITED exec/s: 0 rss: 27Mb
ERROR: no interesting inputs were found. Is the code instrumented for coverage? Exiting.
```