### PR TITLE
add debug lineinfo to template

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -18,6 +18,9 @@ path = ".."
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
+
+[profile.release]
+debug = 1
 "##,
             name = $name,
             edition = if let Some(edition) = &$edition {


### PR DESCRIPTION
Adding line info to the release profile enables line and column numbers in backtraces when a crash is found, and shouldn't affect build time or runtime of the fuzz target