### PR TITLE
Add `check` subcommand to perform a `cargo check`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,10 @@ enum Command {
     /// Build fuzz targets
     Build(options::Build),
 
+    #[structopt(template(LONG_ABOUT_TEMPLATE))]
+    /// Type-check the fuzz targets
+    Check(options::Check),
+
     /// Print the `std::fmt::Debug` output for an input
     Fmt(options::Fmt),
 
@@ -146,6 +150,7 @@ impl RunCommand for Command {
             Command::Init(x) => x.run_command(),
             Command::Add(x) => x.run_command(),
             Command::Build(x) => x.run_command(),
+            Command::Check(x) => x.run_command(),
             Command::List(x) => x.run_command(),
             Command::Fmt(x) => x.run_command(),
             Command::Run(x) => x.run_command(),

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,5 +1,6 @@
 mod add;
 mod build;
+mod check;
 mod cmin;
 mod coverage;
 mod fmt;
@@ -9,8 +10,8 @@ mod run;
 mod tmin;
 
 pub use self::{
-    add::Add, build::Build, cmin::Cmin, coverage::Coverage, fmt::Fmt, init::Init, list::List,
-    run::Run, tmin::Tmin,
+    add::Add, build::Build, check::Check, cmin::Cmin, coverage::Coverage, fmt::Fmt, init::Init,
+    list::List, run::Run, tmin::Tmin,
 };
 
 use std::str::FromStr;
@@ -55,6 +56,12 @@ impl FromStr for Sanitizer {
             _ => Err(format!("unknown sanitizer: {}", s)),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BuildMode {
+    Build,
+    Check,
 }
 
 #[derive(Clone, Debug, StructOpt, PartialEq)]

--- a/src/options/check.rs
+++ b/src/options/check.rs
@@ -7,22 +7,22 @@ use anyhow::Result;
 use structopt::StructOpt;
 
 #[derive(Clone, Debug, StructOpt)]
-pub struct Build {
+pub struct Check {
     #[structopt(flatten)]
     pub build: BuildOptions,
 
     #[structopt(flatten)]
     pub fuzz_dir_wrapper: FuzzDirWrapper,
 
-    /// Name of the fuzz target to build, or build all targets if not supplied
+    /// Name of the fuzz target to check, or check all targets if not supplied
     pub target: Option<String>,
 }
 
-impl RunCommand for Build {
+impl RunCommand for Check {
     fn run_command(&mut self) -> Result<()> {
         let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
         project.exec_build(
-            BuildMode::Build,
+            BuildMode::Check,
             &self.build,
             self.target.as_deref().map(|s| s),
         )


### PR DESCRIPTION
`cargo fuzz check`. Useful for CI where you aren't going to **run** the fuzz target, only verify that it compiles. (Running is left to OSS-Fuzz.)