### PR TITLE
Suggest original flags in `tmin` reproducer command

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -566,8 +566,16 @@ impl FuzzProject {
                 eprintln!();
             }
 
+            let fuzz_dir = if self.fuzz_dir_is_default_path() {
+                String::new()
+            } else {
+                format!(" --fuzz-dir {}", self.fuzz_dir().display())
+            };
+
             eprintln!(
-                "Reproduce with:\n\n\tcargo fuzz run {target} {artifact}\n",
+                "Reproduce with:\n\n\tcargo fuzz run{fuzz_dir}{options} {target} {artifact}\n",
+                fuzz_dir = &fuzz_dir,
+                options = &tmin.build,
                 target = &tmin.target,
                 artifact = artifact.display()
             );

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -336,82 +336,85 @@ fn run_without_sanitizer_with_crash() {
         .failure();
 }
 
-#[test]
-fn run_with_msan_no_crash() {
-    let project = project("run_with_msan_no_crash")
-        .with_fuzz()
-        .fuzz_target(
-            "msan_no_crash",
-            r#"
-                #![no_main]
-                use libfuzzer_sys::fuzz_target;
-
-                fuzz_target!(|data: &[u8]| {
-                    // get data from fuzzer and print it
-                    // to force a memory access that cannot be optimized out
-                    if let Some(x) = data.get(0) {
-                        dbg!(x);
-                    }
-                });
-            "#,
-        )
-        .build();
-
-    project
-        .cargo_fuzz()
-        .arg("run")
-        .arg("--sanitizer=memory")
-        .arg("msan_no_crash")
-        .arg("--")
-        .arg("-runs=1000")
-        .assert()
-        .stderr(predicate::str::contains("Done 1000 runs"))
-        .success();
-}
-
-#[test]
-fn run_with_msan_with_crash() {
-    let project = project("run_with_msan_with_crash")
-        .with_fuzz()
-        .fuzz_target(
-            "msan_with_crash",
-            r#"
-                #![no_main]
-                use libfuzzer_sys::fuzz_target;
-
-                fuzz_target!(|data: &[u8]| {
-                    let test_data: Vec<u8> = Vec::with_capacity(4);
-                    let uninitialized_value = unsafe {test_data.get_unchecked(0)};
-                    // prevent uninit read from being optimized out
-                    println!("{}", uninitialized_value);
-                });
-            "#,
-        )
-        .build();
-
-    project
-        .cargo_fuzz()
-        .arg("run")
-        .arg("--sanitizer=memory")
-        .arg("msan_with_crash")
-        .arg("--")
-        .arg("-runs=1000")
-        .assert()
-        .stderr(
-            predicate::str::contains("MemorySanitizer: use-of-uninitialized-value")
-                .and(predicate::str::contains(
-                    "Reproduce with:\n\
-                \n\
-                \tcargo fuzz run --sanitizer=memory msan_with_crash fuzz/artifacts/msan_with_crash/crash-",
-                ))
-                .and(predicate::str::contains(
-                    "Minimize test case with:\n\
-                \n\
-                \tcargo fuzz tmin --sanitizer=memory msan_with_crash fuzz/artifacts/msan_with_crash/crash-",
-                )),
-        )
-        .failure();
-}
+// TODO: these msan tests are crashing `rustc` in CI:
+// https://github.com/rust-fuzz/cargo-fuzz/issues/323
+//
+// #[test]
+// fn run_with_msan_no_crash() {
+//     let project = project("run_with_msan_no_crash")
+//         .with_fuzz()
+//         .fuzz_target(
+//             "msan_no_crash",
+//             r#"
+//                 #![no_main]
+//                 use libfuzzer_sys::fuzz_target;
+//
+//                 fuzz_target!(|data: &[u8]| {
+//                     // get data from fuzzer and print it
+//                     // to force a memory access that cannot be optimized out
+//                     if let Some(x) = data.get(0) {
+//                         dbg!(x);
+//                     }
+//                 });
+//             "#,
+//         )
+//         .build();
+//
+//     project
+//         .cargo_fuzz()
+//         .arg("run")
+//         .arg("--sanitizer=memory")
+//         .arg("msan_no_crash")
+//         .arg("--")
+//         .arg("-runs=1000")
+//         .assert()
+//         .stderr(predicate::str::contains("Done 1000 runs"))
+//         .success();
+// }
+//
+// #[test]
+// fn run_with_msan_with_crash() {
+//     let project = project("run_with_msan_with_crash")
+//         .with_fuzz()
+//         .fuzz_target(
+//             "msan_with_crash",
+//             r#"
+//                 #![no_main]
+//                 use libfuzzer_sys::fuzz_target;
+//
+//                 fuzz_target!(|data: &[u8]| {
+//                     let test_data: Vec<u8> = Vec::with_capacity(4);
+//                     let uninitialized_value = unsafe {test_data.get_unchecked(0)};
+//                     // prevent uninit read from being optimized out
+//                     println!("{}", uninitialized_value);
+//                 });
+//             "#,
+//         )
+//         .build();
+//
+//     project
+//         .cargo_fuzz()
+//         .arg("run")
+//         .arg("--sanitizer=memory")
+//         .arg("msan_with_crash")
+//         .arg("--")
+//         .arg("-runs=1000")
+//         .assert()
+//         .stderr(
+//             predicate::str::contains("MemorySanitizer: use-of-uninitialized-value")
+//                 .and(predicate::str::contains(
+//                     "Reproduce with:\n\
+//                 \n\
+//                 \tcargo fuzz run --sanitizer=memory msan_with_crash fuzz/artifacts/msan_with_crash/crash-",
+//                 ))
+//                 .and(predicate::str::contains(
+//                     "Minimize test case with:\n\
+//                 \n\
+//                 \tcargo fuzz tmin --sanitizer=memory msan_with_crash fuzz/artifacts/msan_with_crash/crash-",
+//                 )),
+//         )
+//         .failure();
+// }
 
 #[test]
 fn run_one_input() {

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -654,6 +654,7 @@ fn tmin() {
         .cargo_fuzz()
         .arg("tmin")
         .arg("i_hate_zed")
+        .arg("--sanitizer=none")
         .arg(&test_case)
         .assert()
         .stderr(
@@ -668,7 +669,7 @@ fn tmin() {
                 .and(predicate::str::contains(
                     "Reproduce with:\n\
                      \n\
-                     \tcargo fuzz run i_hate_zed fuzz/artifacts/i_hate_zed/minimized-from-"
+                     \tcargo fuzz run --sanitizer=none i_hate_zed fuzz/artifacts/i_hate_zed/minimized-from-"
                 )),
         )
         .success();


### PR DESCRIPTION
Annoying to be using `--sanitizer=none`, minimize a test case, and then copy paste the reproducer but it didn't have `--sanitizer=none` so you have to rebuild the whole thing. This fixes it so that it suggests the original flags, same as regular `cargo fuzz run`.