### PR TITLE
Run deploy actions with correct tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: deploy
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - '*.*.*'
 
 jobs:
 


### PR DESCRIPTION
Tags are written without the `v` char, so let's update the deploy actions script