### PR TITLE
Add an option to disable instrumenting Rust code for fuzzing

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -126,6 +126,10 @@ pub struct BuildOptions {
     #[arg(long)]
     pub no_cfg_fuzzing: bool,
 
+    /// Do not instrument Rust code for fuzzing
+    #[arg(long)]
+    pub no_rust_fuzzing: bool,
+
     #[arg(long)]
     /// Don't build with the `sanitizer-coverage-trace-compares` LLVM argument
     ///

--- a/src/project.rs
+++ b/src/project.rs
@@ -163,11 +163,16 @@ impl FuzzProject {
             cmd.arg("-Z").arg("build-std");
         }
 
-        let mut rustflags: String = "-Cpasses=sancov-module \
+        let mut rustflags = String::new();
+
+        if !build.no_rust_fuzzing {
+            rustflags.push_str(
+                "-Cpasses=sancov-module \
                                      -Cllvm-args=-sanitizer-coverage-level=4 \
                                      -Cllvm-args=-sanitizer-coverage-inline-8bit-counters \
-                                     -Cllvm-args=-sanitizer-coverage-pc-table"
-            .to_owned();
+                                     -Cllvm-args=-sanitizer-coverage-pc-table",
+            );
+        }
 
         if !build.no_trace_compares {
             rustflags.push_str(" -Cllvm-args=-sanitizer-coverage-trace-compares");


### PR DESCRIPTION
The reason for this is sometimes I only want to fuzz the specific part of code, and don't want to fuzz the whole Rust crate stack.