### PR TITLE
fix: use cargo-metadata to support init command in workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,17 +56,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-fuzz"
 version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "cargo_metadata",
  "clap",
  "current_platform",
  "predicates",
  "rustc_version",
  "tempfile",
  "toml",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34637b3140142bdf929fb439e8aa4ebad7651ebf7b1080b3930aa16ac1459ff"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -106,7 +139,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -237,6 +270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
 name = "libc"
 version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,7 +359,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "version_check",
 ]
 
@@ -337,18 +376,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -418,16 +457,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
 name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "strsim"
@@ -440,6 +513,17 @@ name = "syn"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -474,6 +558,26 @@ name = "termtree"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
+
+[[package]]
+name = "thiserror"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
 
 [[package]]
 name = "toml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4.0.29", features = ["derive", "deprecated"] }
 tempfile = "3.3.0"
 toml = "0.5.9"
 rustc_version = "0.4.0"
+cargo_metadata = "0.18.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.7"

--- a/src/options/add.rs
+++ b/src/options/add.rs
@@ -15,8 +15,7 @@ pub struct Add {
 impl RunCommand for Add {
     fn run_command(&mut self) -> Result<()> {
         let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
-        let fuzz_manifest_path = project.fuzz_dir().join("Cargo.toml");
-        let manifest = Manifest::parse(&fuzz_manifest_path)?;
+        let manifest = Manifest::parse()?;
         project.add_target(self, &manifest)
     }
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -932,7 +932,12 @@ pub struct Manifest {
 impl Manifest {
     pub fn parse() -> Result<Self> {
         let metatdata = MetadataCommand::new().exec()?;
-        let package = metatdata.packages.first().expect("at least one package");
+        let package = metatdata.packages.first().with_context(|| {
+            anyhow!(
+                "Expected to find at least one package in {}",
+                metatdata.target_directory
+            )
+        })?;
         let crate_name = package.name.clone();
         let edition = Some(String::from(package.edition.as_str()));
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -53,8 +53,7 @@ impl FuzzProject {
     pub fn init(init: &options::Init, fuzz_dir_opt: Option<PathBuf>) -> Result<Self> {
         let project = Self::manage_initial_instance(fuzz_dir_opt)?;
         let fuzz_project = project.fuzz_dir();
-        let root_project_manifest_path = project.project_dir.join("Cargo.toml");
-        let manifest = Manifest::parse(&root_project_manifest_path)?;
+        let manifest = Manifest::parse()?;
 
         // TODO: check if the project is already initialized
         fs::create_dir(fuzz_project)
@@ -931,16 +930,9 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    pub fn parse(path: &Path) -> Result<Self> {
+    pub fn parse() -> Result<Self> {
         let metatdata = MetadataCommand::new().exec()?;
-        let package = metatdata
-            .packages
-            .iter()
-            .find(|p| p.manifest_path == path)
-            .expect({
-                let path = path.display();
-                &format!("could not find package for {}", path)
-            });
+        let package = metatdata.packages.first().expect("at least one package");
         let crate_name = package.name.clone();
         let edition = Some(String::from(package.edition.as_str()));
 

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -224,7 +224,8 @@ fn run_with_crash() {
         .env("RUST_BACKTRACE", "1")
         .assert()
         .stderr(
-            predicate::str::contains("panicked at 'I'm afraid of number 7'")
+            predicate::str::contains("thread '<unnamed>' panicked at")
+                .and(predicate::str::contains("I'm afraid of number 7"))
                 .and(predicate::str::contains("ERROR: libFuzzer: deadly signal"))
                 .and(predicate::str::contains("run_with_crash::fail_fuzzing"))
                 .and(predicate::str::contains(
@@ -317,7 +318,8 @@ fn run_without_sanitizer_with_crash() {
         .env("RUST_BACKTRACE", "1")
         .assert()
         .stderr(
-            predicate::str::contains("panicked at 'I'm afraid of number 7'")
+            predicate::str::contains("thread '<unnamed>' panicked at")
+                .and(predicate::str::contains("I'm afraid of number 7"))
                 .and(predicate::str::contains("ERROR: libFuzzer: deadly signal"))
                 .and(predicate::str::contains("run_without_sanitizer_with_crash::fail_fuzzing"))
                 .and(predicate::str::contains(

--- a/tests/tests/project.rs
+++ b/tests/tests/project.rs
@@ -140,6 +140,7 @@ impl ProjectBuilder {
             "Cargo.toml",
             &format!(
                 r#"
+                    [workspace]
                     [package]
                     name = "{name}"
                     version = "1.0.0"


### PR DESCRIPTION
closes https://github.com/rust-fuzz/cargo-fuzz/issues/333

Instead of manually parsing the toml file and failing in workspace members, the package name and edition are obtained via cargo-metadata (this also seems to obviate the need to pass that path which is a breaking change to a public API). The way the tests are setup was making cargo-metadata think that each test is a member of cargo-fuzz so I added an empty `workspace` entry to the tests' Cargo.toml. 