### PR TITLE
add llvm-path option

### DIFF
--- a/src/options/coverage.rs
+++ b/src/options/coverage.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::{
     options::{BuildOptions, FuzzDirWrapper},
     project::FuzzProject,
@@ -13,6 +15,10 @@ pub struct Coverage {
 
     #[command(flatten)]
     pub fuzz_dir_wrapper: FuzzDirWrapper,
+
+    /// Sets the path to the LLVM bin directory. By default, it will use the one installed with rustc
+    #[arg(long)]
+    pub llvm_path: Option<PathBuf>,
 
     /// Name of the fuzz target
     pub target: String,

--- a/src/project.rs
+++ b/src/project.rs
@@ -699,7 +699,14 @@ impl FuzzProject {
                 .context("Failed to generage coverage data")?;
             }
         }
-        self.merge_coverage(&coverage_out_raw_dir, &coverage_out_file)?;
+
+        let mut profdata_bin_path = coverage.llvm_path.clone().unwrap_or(rustlib()?);
+        profdata_bin_path.push(format!("llvm-profdata{}", env::consts::EXE_SUFFIX));
+        self.merge_coverage(
+            &profdata_bin_path,
+            &coverage_out_raw_dir,
+            &coverage_out_file,
+        )?;
 
         Ok(())
     }
@@ -749,10 +756,13 @@ impl FuzzProject {
         Ok((cmd, dummy_corpus))
     }
 
-    fn merge_coverage(&self, profdata_raw_path: &Path, profdata_out_path: &Path) -> Result<()> {
-        let mut profdata_path = rustlib()?;
-        profdata_path.push(format!("llvm-profdata{}", env::consts::EXE_SUFFIX));
-        let mut merge_cmd = Command::new(profdata_path);
+    fn merge_coverage(
+        &self,
+        profdata_bin_path: &Path,
+        profdata_raw_path: &Path,
+        profdata_out_path: &Path,
+    ) -> Result<()> {
+        let mut merge_cmd = Command::new(profdata_bin_path);
         merge_cmd.arg("merge").arg("-sparse");
         merge_cmd.arg(profdata_raw_path);
         merge_cmd.arg("-o").arg(profdata_out_path);


### PR DESCRIPTION
This allows the usage of an already installed `llvm-profdata` binary.
If the user does not provide an `llvm-path` cargo-fuzz will try to use the one installed through `rustup component add llvm-tools-preview`. 
If that fails the same instructions to install `llvm-tools-preview` as before as shown.

The name of the option and the fact that a user should set it to the bin folder of an LLVM installation (not to the binary itself) follows the same convention as `grcov`.

Closes #353 

Let me know if something needs to change, or if there's a reason why we should avoid allowing the user to set its own `llvm-profdata`