### PR TITLE
Do not list dependency packages by MetadataCommand

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -938,11 +938,11 @@ pub struct Manifest {
 
 impl Manifest {
     pub fn parse() -> Result<Self> {
-        let metatdata = MetadataCommand::new().exec()?;
-        let package = metatdata.packages.first().with_context(|| {
+        let metadata = MetadataCommand::new().no_deps().exec()?;
+        let package = metadata.packages.first().with_context(|| {
             anyhow!(
                 "Expected to find at least one package in {}",
-                metatdata.target_directory
+                metadata.target_directory
             )
         })?;
         let crate_name = package.name.clone();


### PR DESCRIPTION
When following `cargo-fuzz` tutorial at
https://rust-fuzz.github.io/book/cargo-fuzz/tutorial.html, after executing `cargo fuzz init`, `fuzz/Cargo.toml` contains entry `[dependencies.matches]` instead of `[dependencies.url]`. This is caused by `MetadataCommand` listing dependency packages in addition to main packages which is not desired.

Current implementation does work as expected if result of `MetadataCommand` contains the first package as the non-dep package but that does not seem to work all the time.