### PR TITLE
Remove note about nightly rust from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ $ cargo install cargo-fuzz
 ```
 
 Note: `libFuzzer` needs LLVM sanitizer support, so this only works on x86-64 Linux, x86-64 macOS
-and Apple-Silicon (aarch64) macOS for now. This also needs a nightly compiler since it uses some
-unstable command-line flags. You'll also need a C++ compiler with C++11 support.
+and Apple-Silicon (aarch64) macOS for now. You'll also need a C++ compiler with C++11 support.
 
 If you have an old version of `cargo fuzz`, you can upgrade with this command:
 


### PR DESCRIPTION
Sorry if this is wrong, I recently ran this for the first time and it worked fine for me without nightly, at least on `rustc 1.74.1`.

```
❯ rustc --version -v
rustc 1.74.1 (a28077b28 2023-12-04)
binary: rustc
commit-hash: a28077b28a02b92985b3a3faecf92813155f1ea1
commit-date: 2023-12-04
host: aarch64-apple-darwin
release: 1.74.1
LLVM version: 17.0.4
```

https://github.com/tetratelabs/wazero/pull/1947