### PR TITLE
Improve docs around enabling workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ cargo install -f cargo-fuzz
 
 Initialize a `cargo fuzz` project for your crate!
 
-### Add `fuzz` directory to `workspace.members` in root `Cargo.toml`
+### If your crate uses cargo workspaces, add `fuzz` directory to `workspace.members` in root `Cargo.toml`
 
 `fuzz` directory can be either a part of an existing workspace (default)
 or use an independent workspace. If latter is desired, you can use


### PR DESCRIPTION
The current README.md makes it sound like using workspaces is required. If the root crate does not enable workspaces, then cargo-fuzz works without any changes.