### PR TITLE
Revert "Add `--cfg fuzzing_repro` when reproducing a crash"

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -126,13 +126,6 @@ pub struct BuildOptions {
     #[arg(long)]
     pub no_cfg_fuzzing: bool,
 
-    #[arg(skip = false)]
-    /// Add the 'cfg(fuzzing-repro)' compilation configuration. This build
-    /// option will be automatically used when running `cargo fuzz run <target>
-    /// <corpus>`. The option will not be shown to the user, which is ensured by
-    /// the `skip` attribute.
-    pub cfg_fuzzing_repro: bool,
-
     #[arg(long)]
     /// Don't build with the `sanitizer-coverage-trace-compares` LLVM argument
     ///
@@ -239,7 +232,6 @@ mod test {
             coverage: false,
             strip_dead_code: false,
             no_cfg_fuzzing: false,
-            cfg_fuzzing_repro: false,
             no_trace_compares: false,
         };
 

--- a/src/options/run.rs
+++ b/src/options/run.rs
@@ -37,7 +37,6 @@ pub struct Run {
 impl RunCommand for Run {
     fn run_command(&mut self) -> Result<()> {
         let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
-        self.build.cfg_fuzzing_repro = !self.corpus.is_empty();
         project.exec_fuzz(self)
     }
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -179,10 +179,6 @@ impl FuzzProject {
             rustflags.push_str(" --cfg fuzzing");
         }
 
-        if build.cfg_fuzzing_repro {
-            rustflags.push_str(" --cfg fuzzing_repro");
-        }
-
         if !build.strip_dead_code {
             rustflags.push_str(" -Clink-dead-code");
         }

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -238,9 +238,6 @@ fn run_no_crash() {
                 use libfuzzer_sys::fuzz_target;
 
                 fuzz_target!(|data: &[u8]| {
-                    #[cfg(fuzzing_repro)]
-                    eprintln!("Reproducing a crash");
-
                     run_no_crash::pass_fuzzing(data);
                 });
             "#,
@@ -254,10 +251,7 @@ fn run_no_crash() {
         .arg("--")
         .arg("-runs=1000")
         .assert()
-        .stderr(
-            predicate::str::contains("Done 1000 runs")
-                .and(predicate::str::contains("Reproducing a crash").not()),
-        )
+        .stderr(predicate::str::contains("Done 1000 runs"))
         .success();
 }
 
@@ -500,9 +494,6 @@ fn run_one_input() {
                 use libfuzzer_sys::fuzz_target;
 
                 fuzz_target!(|data: &[u8]| {
-                    #[cfg(fuzzing_repro)]
-                    eprintln!("Reproducing a crash");
-
                     assert!(data.is_empty());
                 });
             "#,
@@ -518,11 +509,9 @@ fn run_one_input() {
         .arg(corpus.join("pass"))
         .assert()
         .stderr(
-            predicate::str::contains("Running 1 inputs 1 time(s) each.")
-                .and(predicate::str::contains(
-                    "Running: fuzz/corpus/run_one/pass",
-                ))
-                .and(predicate::str::contains("Reproducing a crash")),
+            predicate::str::contains("Running 1 inputs 1 time(s) each.").and(
+                predicate::str::contains("Running: fuzz/corpus/run_one/pass"),
+            ),
         )
         .success();
 }


### PR DESCRIPTION
## Updated Description

This PR now reverts #344 to avoid build cache thrashing when switching between reproducing a fuzz test case and when fuzzing in general.

## Original Description

Changing `RUSTFLAGS` causes a recompile of the entire project so for projects that are expensive to build this option being enabled by default means that workflows which switch back-and-forth between fuzzing and running individual tests generate a full rebuild every time. This adds a `--no-cfg-fuzzing-repro` option on the `cargo fuzz run` CLI to disable this `--cfg` argument from being passed.