### PR TITLE
Prepare for stabilization of sanitizers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod templates;
 mod options;
 mod project;
 mod utils;
+mod rustc_version;
 
 static FUZZ_TARGETS_DIR_OLD: &str = "fuzzers";
 static FUZZ_TARGETS_DIR: &str = "fuzz_targets";

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ use clap::Parser;
 mod templates;
 mod options;
 mod project;
-mod utils;
 mod rustc_version;
+mod utils;
 
 static FUZZ_TARGETS_DIR_OLD: &str = "fuzzers";
 static FUZZ_TARGETS_DIR: &str = "fuzz_targets";

--- a/src/project.rs
+++ b/src/project.rs
@@ -212,7 +212,7 @@ impl FuzzProject {
 
             // Not all sanitizers are stabilized on all platforms.
             // It is infeasible to keep up this code to date with the list.
-            // So we just set `-Zunstable-options`` required for some sanitizers
+            // So we just set `-Zunstable-options` required for some sanitizers
             // whenever we're on nightly on a recent enough compiler,
             // and let the compiler show an error message
             // if the user tries to enable a sanitizer not supported on their stable compiler.

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,4 +1,5 @@
 use crate::options::{self, BuildMode, BuildOptions, Sanitizer};
+use crate::rustc_version::{is_nightly, rust_version_string, sanitizer_flag, RustVersion};
 use crate::utils::default_target;
 use anyhow::{anyhow, bail, Context, Result};
 use cargo_metadata::MetadataCommand;
@@ -6,6 +7,7 @@ use std::collections::HashSet;
 use std::io::Read;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::{
     env, ffi, fs,
     process::{Command, Stdio},
@@ -187,17 +189,39 @@ impl FuzzProject {
             rustflags.push_str(" -Cinstrument-coverage");
         }
 
-        match build.sanitizer {
-            Sanitizer::None => {}
-            Sanitizer::Memory => {
-                // Memory sanitizer requires more flags to function than others:
-                // https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html#memorysanitizer
-                rustflags.push_str(" -Zsanitizer=memory -Zsanitizer-memory-track-origins")
+        if !matches!(build.sanitizer, Sanitizer::None) {
+            // Select the appropriate sanitizer flag for the given rustc version:
+            // either -Zsanitizer or -Csanitizer.
+            let rust_version_string = rust_version_string()?;
+            let rust_version =
+                RustVersion::from_str(&rust_version_string).map_err(|e| anyhow::anyhow!(e))?;
+            let sanitizer_flag = sanitizer_flag(&rust_version)?;
+
+            // Set rustc CLI arguments for the chosen sanitizer
+            match build.sanitizer {
+                Sanitizer::None => {} // should be unreachable
+                Sanitizer::Memory => {
+                    // Memory sanitizer requires more flags to function than others:
+                    // https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html#memorysanitizer
+                    rustflags.push_str(&format!(
+                        " {sanitizer_flag}=memory {sanitizer_flag}-memory-track-origins"
+                    ))
+                }
+                _ => rustflags.push_str(&format!(
+                    " {sanitizer_flag}={sanitizer}",
+                    sanitizer = build.sanitizer
+                )),
             }
-            _ => rustflags.push_str(&format!(
-                " -Zsanitizer={sanitizer}",
-                sanitizer = build.sanitizer
-            )),
+
+            // Not all sanitizers are stabilized on all platforms.
+            // It is infeasible to keep up this code to date with the list.
+            // So we just set `-Zunstable-options`` required for some sanitizers
+            // whenever we're on nightly on a recent enough compiler,
+            // and let the compiler show an error message
+            // if the user tries to enable a sanitizer not supported on their stable compiler.
+            if is_nightly(&rust_version_string) && rust_version.has_sanitizers_on_stable() {
+                rustflags.push_str(" -Zunstable-options")
+            }
         }
 
         if build.careful_mode {

--- a/src/project.rs
+++ b/src/project.rs
@@ -199,7 +199,7 @@ impl FuzzProject {
 
             // Set rustc CLI arguments for the chosen sanitizer
             match build.sanitizer {
-                Sanitizer::None => {} // should be unreachable
+                Sanitizer::None => {} // needs no flags
                 Sanitizer::Memory => {
                     // Memory sanitizer requires more flags to function than others:
                     // https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html#memorysanitizer
@@ -207,10 +207,7 @@ impl FuzzProject {
                         " {sanitizer_flag}=memory {sanitizer_flag}-memory-track-origins"
                     ))
                 }
-                _ => rustflags.push_str(&format!(
-                    " {sanitizer_flag}={sanitizer}",
-                    sanitizer = build.sanitizer
-                )),
+                _ => rustflags.push_str(&format!(" {sanitizer_flag}={}", build.sanitizer)),
             }
 
             // Not all sanitizers are stabilized on all platforms.

--- a/src/project.rs
+++ b/src/project.rs
@@ -204,7 +204,7 @@ impl FuzzProject {
                     // Memory sanitizer requires more flags to function than others:
                     // https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html#memorysanitizer
                     rustflags.push_str(&format!(
-                        " {sanitizer_flag}=memory {sanitizer_flag}-memory-track-origins"
+                        " {sanitizer_flag}=memory -Zsanitizer-memory-track-origins"
                     ))
                 }
                 _ => rustflags.push_str(&format!(" {sanitizer_flag}={}", build.sanitizer)),

--- a/src/project.rs
+++ b/src/project.rs
@@ -189,8 +189,7 @@ impl FuzzProject {
         }
 
         if !matches!(build.sanitizer, Sanitizer::None) {
-            // Select the appropriate sanitizer flag for the given rustc version:
-            // either -Zsanitizer or -Csanitizer.
+            // Select the appropriate sanitizer flag for the given rustc version
             let rust_version = RustVersion::discover()?;
             let sanitizer_flag = match rust_version.has_sanitizers_on_stable() {
                 true => "-Csanitizer",

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,5 +1,5 @@
 use crate::options::{self, BuildMode, BuildOptions, Sanitizer};
-use crate::rustc_version::{is_nightly, rust_version_string, sanitizer_flag, RustVersion};
+use crate::rustc_version::{is_nightly, rust_version_string, RustVersion};
 use crate::utils::default_target;
 use anyhow::{anyhow, bail, Context, Result};
 use cargo_metadata::MetadataCommand;
@@ -195,7 +195,10 @@ impl FuzzProject {
             let rust_version_string = rust_version_string()?;
             let rust_version =
                 RustVersion::from_str(&rust_version_string).map_err(|e| anyhow::anyhow!(e))?;
-            let sanitizer_flag = sanitizer_flag(&rust_version)?;
+            let sanitizer_flag = match rust_version.has_sanitizers_on_stable() {
+                true => "-Csanitizer",
+                false => "-Zsanitizer",
+            };
 
             // Set rustc CLI arguments for the chosen sanitizer
             match build.sanitizer {

--- a/src/rustc_version.rs
+++ b/src/rustc_version.rs
@@ -2,22 +2,24 @@
 
 use std::{cmp::Ordering, process::Command, str::FromStr};
 
+use anyhow::Context;
+
 /// Checks if the compiler currently in use is nightly, or `RUSTC_BOOTSTRAP` is set to get nightly features on stable
 pub fn is_nightly(version_string: &str) -> bool {
     version_string.contains("-nightly ") || std::env::var_os("RUSTC_BOOTSTRAP").is_some()
 }
 
 /// Returns the output of `rustc --version`
-pub fn rust_version_string() -> String {
+pub fn rust_version_string() -> anyhow::Result<String> {
     // The path to rustc can be specified via an environment variable:
     // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads
     let rustc_path = std::env::var_os("RUSTC").unwrap_or("rustc".into());
     let raw_output = Command::new(rustc_path)
         .arg("--version")
         .output()
-        .expect("Failed to invoke rustc! Is it in your $PATH?")
+        .context("Failed to invoke rustc! Is it in your $PATH?")?
         .stdout;
-    String::from_utf8(raw_output).expect("`rustc --version` returned non-text output somehow")
+    String::from_utf8(raw_output).context("`rustc --version` returned non-text output somehow")
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd)]

--- a/src/rustc_version.rs
+++ b/src/rustc_version.rs
@@ -40,18 +40,32 @@ impl FromStr for RustVersion {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.strip_prefix("rustc ").ok_or("Rust version string does not start with 'rustc'!")?;
+        let s = s
+            .strip_prefix("rustc ")
+            .ok_or("Rust version string does not start with 'rustc'!")?;
         let mut iter = s.split('.');
-        let major: u32 = iter.next().ok_or("No major version found in `rustc --version` output!")?.parse().map_err(|_| "Failed to parse major version in `rustc --version` output as a number!")?;
-        let minor: u32 = iter.next().ok_or("No minor version found in `rustc --version` output!")?.parse().map_err(|_| "Failed to parse minor version in `rustc --version` output as a number!")?;
-        Ok(RustVersion {major, minor})
+        let major: u32 = iter
+            .next()
+            .ok_or("No major version found in `rustc --version` output!")?
+            .parse()
+            .map_err(|_| {
+                "Failed to parse major version in `rustc --version` output as a number!"
+            })?;
+        let minor: u32 = iter
+            .next()
+            .ok_or("No minor version found in `rustc --version` output!")?
+            .parse()
+            .map_err(|_| {
+                "Failed to parse minor version in `rustc --version` output as a number!"
+            })?;
+        Ok(RustVersion { major, minor })
     }
 }
 
 /// Checks whether the compiler supports sanitizers on stable channel.
 /// Such compilers (even nightly) do not support `-Zsanitizer` flag,
 /// and require a different combination of flags even on nightly.
-/// 
+///
 /// Stabilization PR with more info: <https://github.com/rust-lang/rust/pull/123617>
 impl RustVersion {
     fn has_sanitizers_on_stable(version: &Self) -> bool {
@@ -73,7 +87,13 @@ mod tests {
     fn test_parsing_stable() {
         let version_string = "rustc 1.78.0 (9b00956e5 2024-04-29)";
         let result = RustVersion::from_str(version_string).unwrap();
-        assert_eq!(result, RustVersion { major: 1, minor: 78});
+        assert_eq!(
+            result,
+            RustVersion {
+                major: 1,
+                minor: 78
+            }
+        );
         assert!(!is_nightly(version_string))
     }
 
@@ -81,7 +101,13 @@ mod tests {
     fn test_parsing_nightly() {
         let version_string = "rustc 1.81.0-nightly (d7f6ebace 2024-06-16)";
         let result = RustVersion::from_str(version_string).unwrap();
-        assert_eq!(result, RustVersion { major: 1, minor: 81});
+        assert_eq!(
+            result,
+            RustVersion {
+                major: 1,
+                minor: 81
+            }
+        );
         assert!(is_nightly(version_string))
     }
 
@@ -89,7 +115,13 @@ mod tests {
     fn test_parsing_future_stable() {
         let version_string = "rustc 2.356.1 (deadfaced 2029-04-01)";
         let result = RustVersion::from_str(version_string).unwrap();
-        assert_eq!(result, RustVersion { major: 2, minor: 356});
+        assert_eq!(
+            result,
+            RustVersion {
+                major: 2,
+                minor: 356
+            }
+        );
         assert!(!is_nightly(version_string))
     }
 }

--- a/src/rustc_version.rs
+++ b/src/rustc_version.rs
@@ -22,18 +22,6 @@ pub fn rust_version_string() -> anyhow::Result<String> {
     String::from_utf8(raw_output).context("`rustc --version` returned non-text output somehow")
 }
 
-/// Returns either "-Zsanitizer" or "-Csanitizer" depending on the compiler version.
-///
-/// Stabilization of sanitizers has removed the "-Zsanitizer" flag, even on nightly,
-/// so we have to choose the appropriate flag for the compiler version.
-/// More info: <https://github.com/rust-lang/rust/pull/123617>
-pub fn sanitizer_flag(version: &RustVersion) -> anyhow::Result<&'static str> {
-    match version.has_sanitizers_on_stable() {
-        true => Ok("-Csanitizer"),
-        false => Ok("-Zsanitizer"),
-    }
-}
-
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd)]
 pub struct RustVersion {
     pub major: u32,

--- a/src/rustc_version.rs
+++ b/src/rustc_version.rs
@@ -22,6 +22,18 @@ pub fn rust_version_string() -> anyhow::Result<String> {
     String::from_utf8(raw_output).context("`rustc --version` returned non-text output somehow")
 }
 
+/// Returns either "-Zsanitizer" or "-Csanitizer" depending on the compiler version.
+///
+/// Stabilization of sanitizers has removed the "-Zsanitizer" flag, even on nightly,
+/// so we have to choose the appropriate flag for the compiler version.
+/// More info: <https://github.com/rust-lang/rust/pull/123617>
+pub fn sanitizer_flag(version: &RustVersion) -> anyhow::Result<&'static str> {
+    match version.has_sanitizers_on_stable() {
+        true => Ok("-Csanitizer"),
+        false => Ok("-Zsanitizer"),
+    }
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd)]
 pub struct RustVersion {
     pub major: u32,
@@ -70,14 +82,14 @@ impl FromStr for RustVersion {
 ///
 /// Stabilization PR with more info: <https://github.com/rust-lang/rust/pull/123617>
 impl RustVersion {
-    fn has_sanitizers_on_stable(version: &Self) -> bool {
+    pub fn has_sanitizers_on_stable(&self) -> bool {
         // TODO: the release that stabilizes sanitizers is not currently known.
         // This value is a PLACEHOLDER.
         let release_that_stabilized_sanitizers = RustVersion {
             major: 1,
             minor: 85,
         };
-        version >= &release_that_stabilized_sanitizers
+        self >= &release_that_stabilized_sanitizers
     }
 }
 

--- a/src/rustc_version.rs
+++ b/src/rustc_version.rs
@@ -88,8 +88,8 @@ impl RustVersion {
         // TODO: the release that stabilizes sanitizers is not currently known.
         // This value is a PLACEHOLDER.
         let release_that_stabilized_sanitizers = RustVersion {
-            major: 1,
-            minor: 85,
+            major: u32::MAX,
+            minor: u32::MAX,
             nightly: false,
         };
         self >= &release_that_stabilized_sanitizers

--- a/src/rustc_version.rs
+++ b/src/rustc_version.rs
@@ -1,0 +1,95 @@
+//! Rust compiler version detection
+
+use std::{cmp::Ordering, process::Command, str::FromStr};
+
+/// Checks if the compiler currently in use is nightly, or `RUSTC_BOOTSTRAP` is set to get nightly features on stable
+pub fn is_nightly(version_string: &str) -> bool {
+    version_string.contains("-nightly ") || std::env::var_os("RUSTC_BOOTSTRAP").is_some()
+}
+
+/// Returns the output of `rustc --version`
+pub fn rust_version_string() -> String {
+    // The path to rustc can be specified via an environment variable:
+    // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads
+    let rustc_path = std::env::var_os("RUSTC").unwrap_or("rustc".into());
+    let raw_output = Command::new(rustc_path)
+        .arg("--version")
+        .output()
+        .expect("Failed to invoke rustc! Is it in your $PATH?")
+        .stdout;
+    String::from_utf8(raw_output).expect("`rustc --version` returned non-text output somehow")
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd)]
+pub struct RustVersion {
+    pub major: u32,
+    pub minor: u32,
+    // we don't care about the patch version and it's a bit of a pain to parse
+}
+
+impl Ord for RustVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.major.cmp(&other.major) {
+            Ordering::Equal => self.minor.cmp(&other.minor),
+            other => other,
+        }
+    }
+}
+
+impl FromStr for RustVersion {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_prefix("rustc ").ok_or("Rust version string does not start with 'rustc'!")?;
+        let mut iter = s.split('.');
+        let major: u32 = iter.next().ok_or("No major version found in `rustc --version` output!")?.parse().map_err(|_| "Failed to parse major version in `rustc --version` output as a number!")?;
+        let minor: u32 = iter.next().ok_or("No minor version found in `rustc --version` output!")?.parse().map_err(|_| "Failed to parse minor version in `rustc --version` output as a number!")?;
+        Ok(RustVersion {major, minor})
+    }
+}
+
+/// Checks whether the compiler supports sanitizers on stable channel.
+/// Such compilers (even nightly) do not support `-Zsanitizer` flag,
+/// and require a different combination of flags even on nightly.
+/// 
+/// Stabilization PR with more info: <https://github.com/rust-lang/rust/pull/123617>
+impl RustVersion {
+    fn has_sanitizers_on_stable(version: &Self) -> bool {
+        // TODO: the release that stabilizes sanitizers is not currently known.
+        // This value is a PLACEHOLDER.
+        let release_that_stabilized_sanitizers = RustVersion {
+            major: 1,
+            minor: 85,
+        };
+        version >= &release_that_stabilized_sanitizers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parsing_stable() {
+        let version_string = "rustc 1.78.0 (9b00956e5 2024-04-29)";
+        let result = RustVersion::from_str(version_string).unwrap();
+        assert_eq!(result, RustVersion { major: 1, minor: 78});
+        assert!(!is_nightly(version_string))
+    }
+
+    #[test]
+    fn test_parsing_nightly() {
+        let version_string = "rustc 1.81.0-nightly (d7f6ebace 2024-06-16)";
+        let result = RustVersion::from_str(version_string).unwrap();
+        assert_eq!(result, RustVersion { major: 1, minor: 81});
+        assert!(is_nightly(version_string))
+    }
+
+    #[test]
+    fn test_parsing_future_stable() {
+        let version_string = "rustc 2.356.1 (deadfaced 2029-04-01)";
+        let result = RustVersion::from_str(version_string).unwrap();
+        assert_eq!(result, RustVersion { major: 2, minor: 356});
+        assert!(!is_nightly(version_string))
+    }
+}


### PR DESCRIPTION
The stabilization of sanitizers is expected to remove the `-Zsanitizer` flag we rely on: https://github.com/rust-lang/rust/pull/123617

This PR adds the logic to handle the compiler options required on newer rustc versions, both stable and nightly.

TODO: wait until sanitizers are actually stabilized, and fill in the correct rustc version on which they were stabilized. Hence the draft status - the code is complete otherwise.