### PR TITLE
Update supported architectures in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,8 @@
 $ cargo install cargo-fuzz
 ```
 
-Note: `libFuzzer` needs LLVM sanitizer support, so this only works on x86-64 Linux, x86-64 macOS
-and Apple-Silicon (aarch64) macOS for now. You'll also need a C++ compiler with C++11 support.
-
-If you have an old version of `cargo fuzz`, you can upgrade with this command:
-
-```sh
-$ cargo install -f cargo-fuzz
-```
+Note: `libFuzzer` needs LLVM sanitizer support, so this only works on x86-64 and Aarch64,
+and only on Unix-lile operating systems (not Windows). You'll also need a C++ compiler with C++11 support.
 
 ## Usage
 


### PR DESCRIPTION
In my tests fuzzing worked perfectly fine on Aarch64 Linux.

Sancov [does not document](https://clang.llvm.org/docs/SanitizerCoverage.html) the list of supported platforms, so list the platforms supported by [Rust ASAN](https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#addresssanitizer), which we enable by default.