### PR TITLE
Windows Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
  "rustc_version",
  "tempfile",
  "toml",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -246,7 +247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -258,7 +259,7 @@ dependencies = [
  "hermit-abi",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -454,7 +455,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -647,13 +648,38 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.0",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm 0.42.0",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -663,10 +689,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -675,10 +713,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -687,13 +743,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "cargo_metadata",
+ "cc",
  "clap",
  "current_platform",
  "predicates",
@@ -104,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ cargo_metadata = "0.18.1"
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 cc = "1.1"
+windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_Security","Win32_System_Threading", "Win32_System_JobObjects"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ toml = "0.5.9"
 rustc_version = "0.4.0"
 cargo_metadata = "0.18.1"
 
+[target.'cfg(target_env = "msvc")'.dependencies]
+cc = "1.1"
+
 [dev-dependencies]
 assert_cmd = "2.0.7"
 predicates = "2.1.4"

--- a/src/project.rs
+++ b/src/project.rs
@@ -365,7 +365,7 @@ impl FuzzProject {
     ) -> Result<HashSet<PathBuf>> {
         let mut artifacts = HashSet::new();
 
-        let artifacts_dir = self.artifacts_for(target)?;
+        let artifacts_dir = dbg!(self.artifacts_for(target)?);
 
         for entry in fs::read_dir(&artifacts_dir).with_context(|| {
             format!(

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,5 +1,5 @@
 use crate::options::{self, BuildMode, BuildOptions, Sanitizer};
-use crate::utils::default_target;
+use crate::utils::{create_job_object, default_target};
 use anyhow::{anyhow, bail, Context, Result};
 use cargo_metadata::MetadataCommand;
 use cc::windows_registry::VsVers;
@@ -477,6 +477,8 @@ impl FuzzProject {
                     cmd.env("PATH", new_path);
                 }
             }
+
+            create_job_object()?;
         }
 
         // When libfuzzer finds failing inputs, those inputs will end up in the

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,32 @@
+use std::ffi::OsString;
+
 /// The default target to pass to cargo, to workaround issue #11.
 pub fn default_target() -> &'static str {
     current_platform::CURRENT_PLATFORM
+}
+
+/// Gets the path to the asan DLL required for the asan instrumented binary to run.
+#[cfg(target_env = "msvc")]
+pub fn get_asan_path() -> Option<std::path::PathBuf> {
+    // The asan DLL sits next to cl & link.exe. So grab the parent path.
+    Some(
+        cc::windows_registry::find_tool(default_target(), "link.exe")?
+            .path()
+            .parent()?
+            .to_owned(),
+    )
+}
+
+/// Append a value to the PATH variable
+#[cfg(target_env = "msvc")]
+pub fn append_to_pathvar(path: &std::path::Path) -> Option<OsString> {
+    use std::env;
+
+    if let Some(current) = env::var_os("PATH") {
+        let mut current = env::split_paths(&current).collect::<Vec<_>>();
+        current.push(path.to_path_buf());
+        return env::join_paths(current).ok();
+    }
+
+    return None;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,3 +30,95 @@ pub fn append_to_pathvar(path: &std::path::Path) -> Option<OsString> {
 
     return None;
 }
+
+/// Add current process to a Windows Job Object
+/// This means that when the current process is terminated, all children are as well.
+#[cfg(target_env = "msvc")]
+pub fn create_job_object() -> anyhow::Result<()> {
+    use anyhow::bail;
+    use std::{mem::MaybeUninit, ptr};
+    use windows_sys::Win32::System::{
+        JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+            QueryInformationJobObject, SetInformationJobObject,
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        },
+        Threading::GetCurrentProcess,
+    };
+
+    // Safety: Both parameters are optional. The first parameter being null
+    // ensures that the child processes cannot inherit the job handle.
+    // The second argument means that it is anonymous.
+    let maybe_handle = unsafe { CreateJobObjectW(ptr::null(), ptr::null()) };
+
+    // If the handle is null, the above function failed. If it is non-null, it succeeded.
+    if maybe_handle == 0 {
+        bail!("invalid job handle returned");
+    }
+
+    let mut info = MaybeUninit::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>::uninit();
+
+    // Safety:
+    // We pass in a MaybeUninit extended info object, and then also give the size of it as the size parameter.
+    // The return length is optional, so we set it to null.
+    let err = unsafe {
+        QueryInformationJobObject(
+            maybe_handle,
+            JobObjectExtendedLimitInformation,
+            std::ptr::from_mut(&mut info) as _,
+            std::mem::size_of_val(&info) as _,
+            ptr::null_mut(),
+        )
+    };
+
+    // This function returns zero on failure.
+    if err == 0 {
+        bail!("JobObject information query failed");
+    }
+
+    // Safety:
+    // The query infomation called suceeded, so it is now init.
+    let mut info = unsafe { info.assume_init() };
+
+    // Flag for killing children upon closure.
+    info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+    // Safety:
+    // Handle is valid & has set attributes rights
+    // Info object is not exclusively held anywhere and it a valid object for this API.
+    let err = unsafe {
+        SetInformationJobObject(
+            maybe_handle,
+            JobObjectExtendedLimitInformation,
+            std::ptr::from_ref(&info) as _,
+            std::mem::size_of_val(&info) as _,
+        )
+    };
+
+    // Failure is zero
+    if err == 0 {
+        bail!("setting job object information failed");
+    }
+
+    // Safety:
+    // I do not see any preconditions on this function.
+    // Receive the current processes's handle.
+    let this_process = unsafe { GetCurrentProcess() };
+
+    // Safety:
+    // The job is valid and has the ASSIGN_PROCESS access right because we created it.
+    // the handle has the terminate & set quote access right because it is our handle.
+    let err = unsafe { AssignProcessToJobObject(maybe_handle, this_process) };
+
+    if err == 0 {
+        bail!("failed to assign current process to job object")
+    }
+
+    // Note:
+    // We could return the handle, but there is no reason to. All child processes will automatically
+    // be added to the job. As soon as the handle we created is closed, all children will be terminated.
+    //
+    // Since we added ourselves to the Job, is we close the handle manually we will terminate ourselves.
+    // If we allowed our process to exit by exiting main(), Windows will close the handle for us, terminating all children.
+    Ok(())
+}

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -555,7 +555,8 @@ fn run_a_few_inputs() {
         .assert()
         .stderr(
             predicate::str::contains("Running 4 inputs 1 time(s) each.").and(
-                predicate::str::contains("Running: fuzz/corpus/run_few/pass"),
+                predicate::str::contains("Running: fuzz/corpus/run_few/pass")
+                    .or(predicates::str::contains(r"fuzz\corpus\run_few\pass")),
             ),
         )
         .success();

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -103,12 +103,14 @@ fn init_twice() {
         .cargo_fuzz()
         .arg("init")
         .assert()
-        .stderr(predicates::str::contains("File exists (os error 17)").and(
-            predicates::str::contains(format!(
-                "failed to create directory {}",
-                project.fuzz_dir().display()
-            )),
-        ))
+        .stderr(
+            predicates::str::contains("File exists (os error 17)")
+                .or(predicates::str::contains("os error 183"))
+                .and(predicates::str::contains(format!(
+                    "failed to create directory {}",
+                    project.fuzz_dir().display()
+                ))),
+        )
         .failure();
 }
 

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -205,8 +205,10 @@ fn add_twice() {
         .arg("new_fuzz_target")
         .assert()
         .stderr(
-            predicate::str::contains("could not add target")
-                .and(predicate::str::contains("File exists (os error 17)")),
+            predicate::str::contains("could not add target").and(
+                predicate::str::contains("File exists (os error 17)")
+                    .or(predicate::str::contains("os error 80")),
+            ),
         )
         .failure();
 }

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -596,7 +596,12 @@ fn run_alt_corpus() {
         .assert()
         .stderr(
             predicate::str::contains("3 files found in fuzz/alt-corpus/run_alt")
-                .and(predicate::str::contains("fuzz/corpus/run_alt").not())
+                .or(predicates::str::contains(r"fuzz\alt-corpus\run_alt"))
+                .and(
+                    predicate::str::contains("fuzz/corpus/run_alt")
+                        .or(predicates::str::contains(r"fuzz\corpus\run_alt"))
+                        .not(),
+                )
                 // libFuzzer will always test the empty input, so the number of
                 // runs performed is always one more than the number of files in
                 // the corpus.

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -815,8 +815,13 @@ fn build_one() {
     project.cargo_fuzz().arg("build").assert().success();
 
     let build_dir = project.fuzz_build_dir().join("release");
-    let a_bin = build_dir.join("build_one_a");
-    let b_bin = build_dir.join("build_one_b");
+    let mut a_bin = build_dir.join("build_one_a");
+    let mut b_bin = build_dir.join("build_one_b");
+
+    if cfg!(windows) {
+        a_bin.set_extension("exe");
+        b_bin.set_extension("exe");
+    }
 
     // Remove the files we just built.
     fs::remove_file(&a_bin).unwrap();

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -861,8 +861,16 @@ fn build_dev() {
 
     let build_dir = project.fuzz_build_dir().join("debug");
 
-    let a_bin = build_dir.join("build_dev_a");
-    let b_bin = build_dir.join("build_dev_b");
+    let a_bin = build_dir.join(if cfg!(windows) {
+        "build_dev_a.exe"
+    } else {
+        "build_dev_a"
+    });
+    let b_bin = build_dir.join(if cfg!(windows) {
+        "build_dev_b.exe"
+    } else {
+        "build_dev_b"
+    });
 
     // Remove the files we just built.
     fs::remove_file(&a_bin).unwrap();

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -905,7 +905,11 @@ fn build_stripping_dead_code() {
 
     let build_dir = project.fuzz_build_dir().join("debug");
 
-    let a_bin = build_dir.join("build_strip_a");
+    let a_bin = build_dir.join(if cfg!(windows) {
+        "build_strip_a.exe"
+    } else {
+        "build_strip_a"
+    });
     assert!(a_bin.is_file(), "Not a file: {}", a_bin.display());
 }
 

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -770,8 +770,13 @@ fn build_all() {
 
     let build_dir = project.fuzz_build_dir().join("release");
 
-    let a_bin = build_dir.join("build_all_a");
-    let b_bin = build_dir.join("build_all_b");
+    let mut a_bin = build_dir.join("build_all_a");
+    let mut b_bin = build_dir.join("build_all_b");
+
+    if cfg!(windows) {
+        a_bin.set_extension("exe");
+        b_bin.set_extension("exe");
+    }
 
     // Remove the files we just built.
     fs::remove_file(&a_bin).unwrap();

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -514,7 +514,8 @@ fn run_one_input() {
         .assert()
         .stderr(
             predicate::str::contains("Running 1 inputs 1 time(s) each.").and(
-                predicate::str::contains("Running: fuzz/corpus/run_one/pass"),
+                predicate::str::contains("Running: fuzz/corpus/run_one/pass")
+                    .or(predicates::str::contains(r"fuzz\corpus\run_one\pass")),
             ),
         )
         .success();

--- a/tests/tests/project.rs
+++ b/tests/tests/project.rs
@@ -106,12 +106,12 @@ impl ProjectBuilder {
             r#"
                 [[bin]]
                 name = "{name}"
-                path = "{path}"
+                path = {path}
                 test = false
                 doc = false
             "#,
             name = name,
-            path = path.display(),
+            path = toml::to_string(&path).unwrap(),
         )
         .unwrap();
 


### PR DESCRIPTION
Note: I will clean up the commits once it's mostly working

This crate is quite close to supporting Windows. The crates will already build without issue. Things to do:

- [x] Add the directory that `clang_rt.asan_dynamic-x86_64.dll` is in to $PATH of the fuzzer process

With this change it is possible to run the fuzzers too.

This directory is not on PATH by default, so the binary cannot load the DLL when run. It is recommended to add it to PATH before running the binary. It somewhere like
`C:\Program Files (x86)\Microsoft Visual Studio\[MSVC VERSION]\BuildTools\VC\Tools\MSVC\[RT VERSION]\bin\Hostx64\x64`

asan is fairly new to MSVC so it will only exist on versions newer than 2019.

This DLL resides in the same directory as `link.exe` & `cl.exe` so the most accurate way to obtain it is to [do the same process rustc does to get the location of `link.exe`](https://github.com/rust-lang/rust/blob/2ccafed862f6906707a390caf180449dd64cad2e/compiler/rustc_codegen_ssa/src/back/linker.rs#L50). This ensures that the runtime & msvc version matches the one used to compile the binary.

Note: this is required for `sanitizers = none` as well. Windows does not support any other sanitizers at this time.

- [ ] Fix-up tests so that they pass on Windows too

There are errors that are *nix specific that need to be fixed up. It is mainly fixing str paths that will be displayed incorrectly on Windows.

- [x] init_twice  
- [x] add_twice
- [x] build_dev
- [x] build_all
- [x] build_one
- [x] run_a_few_inputs
- [x] run_alt_corpus
- [ ] run_diagnostic_contains_fuzz_dir 
- [x] run_one_input 
- [ ] run_without_sanitizer_with_crash 
- [ ] run_with_crash 
- [ ] run_with_coverage 
- [ ] tmin 

- [x] Ensure child processes are always terminated

The [win32 Job Objects API](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects) is what is needed for this. Essentially, get its info, set the info so that it has JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE set.

- [ ] Ensure the fuzzer runs?

For some reason on my work computer the fuzzer just hangs when it opens, not doing anything. At home it seems to work as expected. I'm not sure why.

<details>
 <summary>Looks like every thread it hanging out in `NtWaitForAlertByThreadId`. IDK what that means. </summary>

```lldb

(lldb) thread backtrace all 
* thread #7
  * frame #0: [33m0x00007ffe84ef0f94[0m ntdll.dll`NtWaitForAlertByThreadId + 20
    frame #1: [33m0x00007ffe84e83270[0m ntdll.dll`RtlLookupFunctionEntry + 1680
    frame #2: [33m0x00007ffe84ea2bb1[0m ntdll.dll`RtlWalkFrameChain + 1169
    frame #3: [33m0x00007ffe84ea28ba[0m ntdll.dll`RtlWalkFrameChain + 410
    frame #4: [33m0x00007ffe84ea274a[0m ntdll.dll`RtlWalkFrameChain + 42
    frame #5: [33m0x00007ffe84ea26e2[0m ntdll.dll`RtlCaptureStackBackTrace + 66
    frame #6: [33m0x00007ffdecb3749c[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_symbolize_pc + 16732
    frame #7: [33m0x00007ffdecb33202[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_dump_trace_pc_guard_coverage + 11650
    frame #8: [33m0x00007ffdecb72c33[0m clang_rt.asan_dynamic-x86_64.dll`__asan_version_mismatch_check_v8 + 1651
    frame #9: [33m0x00007ffdecb6471c[0m clang_rt.asan_dynamic-x86_64.dll`__asan_wrap_RtlAllocateHeap + 444
    frame #10: [33m0x00007ffe84ea4cdf[0m ntdll.dll`RtlLoadString + 4511
    frame #11: [33m0x00007ffe84ea4b2d[0m ntdll.dll`RtlLoadString + 4077
    frame #12: [33m0x00007ffe84e677a7[0m ntdll.dll`LdrShutdownThread + 855
    frame #13: [33m0x00007ffe84ec60a4[0m ntdll.dll`LdrInitializeThunk + 1156
    frame #14: [33m0x00007ffe84ec5c83[0m ntdll.dll`LdrInitializeThunk + 99
    frame #15: [33m0x00007ffe84ec5c2e[0m ntdll.dll`LdrInitializeThunk + 14
  thread #2
    frame #0: [33m0x00007ffe84ef0f94[0m ntdll.dll`NtWaitForAlertByThreadId + 20
    frame #1: [33m0x00007ffe84e83270[0m ntdll.dll`RtlLookupFunctionEntry + 1680
    frame #2: [33m0x00007ffe84ea2bb1[0m ntdll.dll`RtlWalkFrameChain + 1169
    frame #3: [33m0x00007ffe84ea28ba[0m ntdll.dll`RtlWalkFrameChain + 410
    frame #4: [33m0x00007ffe84ea274a[0m ntdll.dll`RtlWalkFrameChain + 42
    frame #5: [33m0x00007ffe84ea26e2[0m ntdll.dll`RtlCaptureStackBackTrace + 66
    frame #6: [33m0x00007ffdecb3749c[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_symbolize_pc + 16732
    frame #7: [33m0x00007ffdecb33202[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_dump_trace_pc_guard_coverage + 11650
    frame #8: [33m0x00007ffdecb72c33[0m clang_rt.asan_dynamic-x86_64.dll`__asan_version_mismatch_check_v8 + 1651
    frame #9: [33m0x00007ffdecb63bec[0m clang_rt.asan_dynamic-x86_64.dll`__asan_wrap_LocalAlloc + 284
    frame #10: [33m0x00007ffe790a98cd[0m TmUmEvt64.dll
    frame #11: [33m0x00007ffe790aa607[0m TmUmEvt64.dll`void TmmonDestoryAddonObject(void) + 1143
    frame #12: [33m0x00007ffe790a99c1[0m TmUmEvt64.dll
    frame #13: [33m0x0000000076a29694[0m tmmon64.dll
    frame #14: [33m0x0000000076a4cd32[0m tmmon64.dll
    frame #15: [33m0x0000000076a4d077[0m tmmon64.dll
    frame #16: [33m0x0000000076973c39[0m tmmon64.dll
    frame #17: [33m0x00007ffe84e9ec5e[0m ntdll.dll`RtlExitUserThread + 46
    frame #18: [33m0x00007ffe84e9dd28[0m ntdll.dll`TpReleaseCleanupGroupMembers + 4200
    frame #19: [33m0x00007ffe848f7374[0m kernel32.dll`BaseThreadInitThunk + 20
    frame #20: [33m0x00007ffe84e9cc91[0m ntdll.dll`RtlUserThreadStart + 33
  thread #1
    frame #0: [33m0x00007ffe84ef0f94[0m ntdll.dll`NtWaitForAlertByThreadId + 20
    frame #1: [33m0x00007ffe84e83270[0m ntdll.dll`RtlLookupFunctionEntry + 1680
    frame #2: [33m0x00007ffe84ea2bb1[0m ntdll.dll`RtlWalkFrameChain + 1169
    frame #3: [33m0x00007ffe84ea28ba[0m ntdll.dll`RtlWalkFrameChain + 410
    frame #4: [33m0x00007ffe84ea274a[0m ntdll.dll`RtlWalkFrameChain + 42
    frame #5: [33m0x00007ffe84ea26e2[0m ntdll.dll`RtlCaptureStackBackTrace + 66
    frame #6: [33m0x00007ffdecb3749c[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_symbolize_pc + 16732
    frame #7: [33m0x00007ffdecb33202[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_dump_trace_pc_guard_coverage + 11650
    frame #8: [33m0x00007ffdecb72c33[0m clang_rt.asan_dynamic-x86_64.dll`__asan_version_mismatch_check_v8 + 1651
    frame #9: [33m0x00007ffdecb3e853[0m clang_rt.asan_dynamic-x86_64.dll`__asan_new_array + 211
    frame #10: [33m0x00007ff6a232ffb2[0m fuzz_target_1.exe`LLVMFuzzerRunDriver + 198482
    frame #11: [33m0x00007ff6a22e43c2[0m fuzz_target_1.exe`__sanitizer_weak_hook_strstr + 64546
    frame #12: [33m0x00007ff6a22e63af[0m fuzz_target_1.exe`__sanitizer_weak_hook_strstr + 72719
    frame #13: [33m0x00007ff6a22e4bd0[0m fuzz_target_1.exe`__sanitizer_weak_hook_strstr + 66608
    frame #14: [33m0x00007ff6a22f928e[0m fuzz_target_1.exe`LLVMFuzzerMutate + 44510
    frame #15: [33m0x00007ff6a22ccb23[0m fuzz_target_1.exe`main + 35
    frame #16: [33m0x00007ff6a23308b8[0m fuzz_target_1.exe`LLVMFuzzerRunDriver + 200792
    frame #17: [33m0x00007ffe848f7374[0m kernel32.dll`BaseThreadInitThunk + 20
    frame #18: [33m0x00007ffe84e9cc91[0m ntdll.dll`RtlUserThreadStart + 33
  thread #6
    frame #0: [33m0x00007ffe84ef0f94[0m ntdll.dll`NtWaitForAlertByThreadId + 20
    frame #1: [33m0x00007ffe84e83270[0m ntdll.dll`RtlLookupFunctionEntry + 1680
    frame #2: [33m0x00007ffe84ea2bb1[0m ntdll.dll`RtlWalkFrameChain + 1169
    frame #3: [33m0x00007ffe84ea28ba[0m ntdll.dll`RtlWalkFrameChain + 410
    frame #4: [33m0x00007ffe84ea274a[0m ntdll.dll`RtlWalkFrameChain + 42
    frame #5: [33m0x00007ffe84ea26e2[0m ntdll.dll`RtlCaptureStackBackTrace + 66
    frame #6: [33m0x00007ffdecb3749c[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_symbolize_pc + 16732
    frame #7: [33m0x00007ffdecb33202[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_dump_trace_pc_guard_coverage + 11650
    frame #8: [33m0x00007ffdecb72c33[0m clang_rt.asan_dynamic-x86_64.dll`__asan_version_mismatch_check_v8 + 1651
    frame #9: [33m0x00007ffdecb6471c[0m clang_rt.asan_dynamic-x86_64.dll`__asan_wrap_RtlAllocateHeap + 444
    frame #10: [33m0x00007ffe84ea4cdf[0m ntdll.dll`RtlLoadString + 4511
    frame #11: [33m0x00007ffe84ea4b2d[0m ntdll.dll`RtlLoadString + 4077
    frame #12: [33m0x00007ffe84e677a7[0m ntdll.dll`LdrShutdownThread + 855
    frame #13: [33m0x00007ffe84ec60a4[0m ntdll.dll`LdrInitializeThunk + 1156
    frame #14: [33m0x00007ffe84ec5c83[0m ntdll.dll`LdrInitializeThunk + 99
    frame #15: [33m0x00007ffe84ec5c2e[0m ntdll.dll`LdrInitializeThunk + 14
  thread #4
    frame #0: [33m0x00007ffe84ef0f94[0m ntdll.dll`NtWaitForAlertByThreadId + 20
    frame #1: [33m0x00007ffe84e83270[0m ntdll.dll`RtlLookupFunctionEntry + 1680
    frame #2: [33m0x00007ffe84ea2bb1[0m ntdll.dll`RtlWalkFrameChain + 1169
    frame #3: [33m0x00007ffe84ea28ba[0m ntdll.dll`RtlWalkFrameChain + 410
    frame #4: [33m0x00007ffe84ea274a[0m ntdll.dll`RtlWalkFrameChain + 42
    frame #5: [33m0x00007ffe84ea26e2[0m ntdll.dll`RtlCaptureStackBackTrace + 66
    frame #6: [33m0x00007ffdecb3749c[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_symbolize_pc + 16732
    frame #7: [33m0x00007ffdecb33202[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_dump_trace_pc_guard_coverage + 11650
    frame #8: [33m0x00007ffdecb72c33[0m clang_rt.asan_dynamic-x86_64.dll`__asan_version_mismatch_check_v8 + 1651
    frame #9: [33m0x00007ffdecb63bec[0m clang_rt.asan_dynamic-x86_64.dll`__asan_wrap_LocalAlloc + 284
    frame #10: [33m0x00007ffe790a98cd[0m TmUmEvt64.dll
    frame #11: [33m0x00007ffe790aa607[0m TmUmEvt64.dll`void TmmonDestoryAddonObject(void) + 1143
    frame #12: [33m0x00007ffe790a99c1[0m TmUmEvt64.dll
    frame #13: [33m0x0000000076a29694[0m tmmon64.dll
    frame #14: [33m0x0000000076a4cd32[0m tmmon64.dll
    frame #15: [33m0x0000000076a4d077[0m tmmon64.dll
    frame #16: [33m0x0000000076973c39[0m tmmon64.dll
    frame #17: [33m0x00007ffe84e9ec5e[0m ntdll.dll`RtlExitUserThread + 46
    frame #18: [33m0x00007ffe84e9dd28[0m ntdll.dll`TpReleaseCleanupGroupMembers + 4200
    frame #19: [33m0x00007ffe848f7374[0m kernel32.dll`BaseThreadInitThunk + 20
    frame #20: [33m0x00007ffe84e9cc91[0m ntdll.dll`RtlUserThreadStart + 33
  thread #5
    frame #0: [33m0x00007ffe84ef0f94[0m ntdll.dll`NtWaitForAlertByThreadId + 20
    frame #1: [33m0x00007ffe84e83270[0m ntdll.dll`RtlLookupFunctionEntry + 1680
    frame #2: [33m0x00007ffe84ea2bb1[0m ntdll.dll`RtlWalkFrameChain + 1169
    frame #3: [33m0x00007ffe84ea28ba[0m ntdll.dll`RtlWalkFrameChain + 410
    frame #4: [33m0x00007ffe84ea274a[0m ntdll.dll`RtlWalkFrameChain + 42
    frame #5: [33m0x00007ffe84ea26e2[0m ntdll.dll`RtlCaptureStackBackTrace + 66
    frame #6: [33m0x00007ffdecb3749c[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_symbolize_pc + 16732
    frame #7: [33m0x00007ffdecb33202[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_dump_trace_pc_guard_coverage + 11650
    frame #8: [33m0x00007ffdecb72c33[0m clang_rt.asan_dynamic-x86_64.dll`__asan_version_mismatch_check_v8 + 1651
    frame #9: [33m0x00007ffdecb6471c[0m clang_rt.asan_dynamic-x86_64.dll`__asan_wrap_RtlAllocateHeap + 444
    frame #10: [33m0x00007ffe790fd6b4[0m TmUmEvt64.dll`void TmmonDestoryAddonObject(void) + 341284
    frame #11: [33m0x00007ffe790e12a3[0m TmUmEvt64.dll`void TmmonDestoryAddonObject(void) + 225555
    frame #12: [33m0x00007ffe790b570f[0m TmUmEvt64.dll`void TmmonDestoryAddonObject(void) + 46463
    frame #13: [33m0x00007ffe790b25e3[0m TmUmEvt64.dll`void TmmonDestoryAddonObject(void) + 33875
    frame #14: [33m0x00007ffe790b36c8[0m TmUmEvt64.dll`void TmmonDestoryAddonObject(void) + 38200
    frame #15: [33m0x00007ffe790b4049[0m TmUmEvt64.dll`void TmmonDestoryAddonObject(void) + 40633
    frame #16: [33m0x00007ffe7901e1e8[0m TmUmEvt64.dll
    frame #17: [33m0x00007ffe79020357[0m TmUmEvt64.dll
    frame #18: [33m0x00007ffe7902030d[0m TmUmEvt64.dll
    frame #19: [33m0x00007ffe7902146b[0m TmUmEvt64.dll
    frame #20: [33m0x00007ffe7905e90c[0m TmUmEvt64.dll
    frame #21: [33m0x00007ffe7905f30c[0m TmUmEvt64.dll
    frame #22: [33m0x00007ffe790a09a3[0m TmUmEvt64.dll
    frame #23: [33m0x00000000769713c6[0m tmmon64.dll
    frame #24: [33m0x0000000076a4cdd2[0m tmmon64.dll
    frame #25: [33m0x0000000076a4d077[0m tmmon64.dll
    frame #26: [33m0x0000000076972fa5[0m tmmon64.dll
    frame #27: [33m0x00007ffe84e6354a[0m ntdll.dll`RtlAddRefActivationContext + 138
    frame #28: [33m0x00007ffe84e62252[0m ntdll.dll`TpIsTimerSet + 594
    frame #29: [33m0x00007ffe84e60921[0m ntdll.dll`RtlIsProcessorFeaturePresent + 177
    frame #30: [33m0x00007ffe84e5fb05[0m ntdll.dll`TpAllocWork + 2085
    frame #31: [33m0x00007ffe84e64bcf[0m ntdll.dll`RtlIsCriticalSectionLockedByThread + 831
    frame #32: [33m0x00007ffe84eb1253[0m ntdll.dll`RtlUnlockHeap + 6211
    frame #33: [33m0x00007ffe84eb0f80[0m ntdll.dll`RtlUnlockHeap + 5488
    frame #34: [33m0x00007ffe84eb021f[0m ntdll.dll`RtlUnlockHeap + 2063
    frame #35: [33m0x00007ffe84e6fb53[0m ntdll.dll`RtlGetFullPathName_UstrEx + 8899
    frame #36: [33m0x00007ffe84e673e4[0m ntdll.dll`RtlDosPathNameToNtPathName_U + 212
    frame #37: [33m0x00007ffe84e66af4[0m ntdll.dll`LdrLoadDll + 228
    frame #38: [33m0x00000000769733c4[0m tmmon64.dll
    frame #39: [33m0x00007ffe825a2612[0m KernelBase.dll`LoadLibraryExW + 354
    frame #40: [33m0x00007ffe8296c050[0m ucrtbase.dll`__stdio_common_vfwprintf + 1264
    frame #41: [33m0x00007ffe8297357b[0m ucrtbase.dll`_o__difftime64 + 203
    frame #42: [33m0x00007ffe82971be4[0m ucrtbase.dll`_configthreadlocale + 196
    frame #43: [33m0x00007ffdecb748ff[0m clang_rt.asan_dynamic-x86_64.dll`__asan_default_suppressions__dll + 4879
    frame #44: [33m0x00007ffe848f7374[0m kernel32.dll`BaseThreadInitThunk + 20
    frame #45: [33m0x00007ffe84e9cc91[0m ntdll.dll`RtlUserThreadStart + 33
  thread #3
    frame #0: [33m0x00007ffe84ef0f94[0m ntdll.dll`NtWaitForAlertByThreadId + 20
    frame #1: [33m0x00007ffe84e83270[0m ntdll.dll`RtlLookupFunctionEntry + 1680
    frame #2: [33m0x00007ffe84ea2bb1[0m ntdll.dll`RtlWalkFrameChain + 1169
    frame #3: [33m0x00007ffe84ea28ba[0m ntdll.dll`RtlWalkFrameChain + 410
    frame #4: [33m0x00007ffe84ea274a[0m ntdll.dll`RtlWalkFrameChain + 42
    frame #5: [33m0x00007ffe84ea26e2[0m ntdll.dll`RtlCaptureStackBackTrace + 66
    frame #6: [33m0x00007ffdecb3749c[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_symbolize_pc + 16732
    frame #7: [33m0x00007ffdecb33202[0m clang_rt.asan_dynamic-x86_64.dll`__sanitizer_dump_trace_pc_guard_coverage + 11650
    frame #8: [33m0x00007ffdecb72c33[0m clang_rt.asan_dynamic-x86_64.dll`__asan_version_mismatch_check_v8 + 1651
    frame #9: [33m0x00007ffdecb63bec[0m clang_rt.asan_dynamic-x86_64.dll`__asan_wrap_LocalAlloc + 284
    frame #10: [33m0x00007ffe790a98cd[0m TmUmEvt64.dll
    frame #11: [33m0x00007ffe790aa607[0m TmUmEvt64.dll`void TmmonDestoryAddonObject(void) + 1143
    frame #12: [33m0x00007ffe790a99c1[0m TmUmEvt64.dll
    frame #13: [33m0x0000000076a29694[0m tmmon64.dll
    frame #14: [33m0x0000000076a4cd32[0m tmmon64.dll
    frame #15: [33m0x0000000076a4d077[0m tmmon64.dll
    frame #16: [33m0x0000000076973c39[0m tmmon64.dll
    frame #17: [33m0x00007ffe84e9ec5e[0m ntdll.dll`RtlExitUserThread + 46
    frame #18: [33m0x00007ffe84e9dd28[0m ntdll.dll`TpReleaseCleanupGroupMembers + 4200
    frame #19: [33m0x00007ffe848f7374[0m kernel32.dll`BaseThreadInitThunk + 20
    frame #20: [33m0x00007ffe84e9cc91[0m ntdll.dll`RtlUserThreadStart + 33

```

</details>