### PR TITLE
Set LLVM Flag to Disable cmov (select instr) generation

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -135,7 +135,7 @@ pub struct BuildOptions {
     /// available.
     pub no_trace_compares: bool,
 
-    #[arg(long)]
+    #[arg(long, default_value = "true")]
     /// Disable transformation of if-statements into `cmov` instructions (when this
     /// happens, we get no coverage feedback for that branch). Default setting is true.
     /// A further explanation can be found here:

--- a/src/options.rs
+++ b/src/options.rs
@@ -135,12 +135,12 @@ pub struct BuildOptions {
     /// available.
     pub no_trace_compares: bool,
 
-    #[arg(long, default_value = "true")]
+    #[arg(long)]
     /// Disable transformation of if-statements into `cmov` instructions (when this
     /// happens, we get no coverage feedback for that branch). Default setting is true.
     /// A further explanation can be found here:
     /// https://github.com/rust-fuzz/cargo-fuzz/pull/380#issue-2445529059
-    pub disable_branch_folding: bool,
+    pub disable_branch_folding: Option<bool>,
 }
 
 impl stdfmt::Display for BuildOptions {
@@ -240,7 +240,7 @@ mod test {
             strip_dead_code: false,
             no_cfg_fuzzing: false,
             no_trace_compares: false,
-            disable_branch_folding: true,
+            disable_branch_folding: None,
         };
 
         let opts = vec![

--- a/src/options.rs
+++ b/src/options.rs
@@ -139,18 +139,18 @@ pub struct BuildOptions {
     /// Disable transformation of if-statements into `cmov` instructions (when this
     /// happens, we get no coverage feedback for that branch). Default setting is true.
     /// This is done by setting the `-simplifycfg-branch-fold-threshold=0` LLVM arg.
-    /// 
-    /// For example, in the following program shows the default coverage feedback when 
+    ///
+    /// For example, in the following program shows the default coverage feedback when
     /// compiled with `-Copt-level=3`:
-    /// 
+    ///
     /// mark_covered(1); // mark edge 1 as covered
     /// let mut res = 1;
     /// if x > 5 && y < 6 {
     ///    res = 2;
     /// }
-    /// 
+    ///
     /// With `disable_branch_folding` enabled, the code compiles to be equivalent to:
-    /// 
+    ///
     /// mark_covered(1);
     /// let mut res = 1;
     /// if x > 5 {
@@ -160,7 +160,7 @@ pub struct BuildOptions {
     ///         res = 2;
     ///     }
     /// }
-    /// 
+    ///
     /// Note, that in the second program, there are now 2 new coverage feedback points,
     /// and the fuzzer can store an input to the corpus at each condition that it passes;
     /// giving it a better chance of producing an input that reaches `res = 2;`.

--- a/src/options.rs
+++ b/src/options.rs
@@ -134,6 +134,13 @@ pub struct BuildOptions {
     /// the `*-trace-compares` instrumentation assumes that the instruction is
     /// available.
     pub no_trace_compares: bool,
+
+    #[arg(long)]
+    /// Disable transformation of if-statements into `cmov` instructions (when this
+    /// happens, we get no coverage feedback for that branch). Default setting is true.
+    /// A further explanation can be found here:
+    /// https://github.com/rust-fuzz/cargo-fuzz/pull/380#issue-2445529059
+    pub disable_branch_folding: bool,
 }
 
 impl stdfmt::Display for BuildOptions {
@@ -233,6 +240,7 @@ mod test {
             strip_dead_code: false,
             no_cfg_fuzzing: false,
             no_trace_compares: false,
+            disable_branch_folding: true,
         };
 
         let opts = vec![

--- a/src/project.rs
+++ b/src/project.rs
@@ -176,7 +176,7 @@ impl FuzzProject {
         }
 
         if build.disable_branch_folding {
-            rustflags.push_str("-Cllvm-args=-simplifycfg-branch-fold-threshold=0");
+            rustflags.push_str(" -Cllvm-args=-simplifycfg-branch-fold-threshold=0");
         }
 
         if !build.no_cfg_fuzzing {

--- a/src/project.rs
+++ b/src/project.rs
@@ -175,7 +175,7 @@ impl FuzzProject {
             rustflags.push_str(" -Cllvm-args=-sanitizer-coverage-trace-compares");
         }
 
-        if build.disable_branch_folding.is_some_and(|v| v) {
+        if build.disable_branch_folding.unwrap_or(true) {
             rustflags.push_str(" -Cllvm-args=-simplifycfg-branch-fold-threshold=0");
         }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -175,7 +175,7 @@ impl FuzzProject {
             rustflags.push_str(" -Cllvm-args=-sanitizer-coverage-trace-compares");
         }
 
-        if build.disable_branch_folding {
+        if build.disable_branch_folding.is_some_and(|v| v) {
             rustflags.push_str(" -Cllvm-args=-simplifycfg-branch-fold-threshold=0");
         }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -168,12 +168,15 @@ impl FuzzProject {
         let mut rustflags: String = "-Cpasses=sancov-module \
                                      -Cllvm-args=-sanitizer-coverage-level=4 \
                                      -Cllvm-args=-sanitizer-coverage-inline-8bit-counters \
-                                     -Cllvm-args=-sanitizer-coverage-pc-table \
-                                     -Cllvm-args=-simplifycfg-branch-fold-threshold=0"
+                                     -Cllvm-args=-sanitizer-coverage-pc-table"
             .to_owned();
 
         if !build.no_trace_compares {
             rustflags.push_str(" -Cllvm-args=-sanitizer-coverage-trace-compares");
+        }
+
+        if build.disable_branch_folding {
+            rustflags.push_str("-Cllvm-args=-simplifycfg-branch-fold-threshold=0");
         }
 
         if !build.no_cfg_fuzzing {

--- a/src/project.rs
+++ b/src/project.rs
@@ -168,7 +168,8 @@ impl FuzzProject {
         let mut rustflags: String = "-Cpasses=sancov-module \
                                      -Cllvm-args=-sanitizer-coverage-level=4 \
                                      -Cllvm-args=-sanitizer-coverage-inline-8bit-counters \
-                                     -Cllvm-args=-sanitizer-coverage-pc-table"
+                                     -Cllvm-args=-sanitizer-coverage-pc-table \
+                                     -Cllvm-args=-simplifycfg-branch-fold-threshold=0"
             .to_owned();
 
         if !build.no_trace_compares {


### PR DESCRIPTION
Hi, I work on fuzzing and I've found this flag to be useful as it breaks up conditional checks, giving coverage feedback after each check in conditionals with `&&`s (by disabling generation of `cmov` instructions - aka `SelectInst` in LLVM API) . As you can imagine, having some checkpoints along the way helps the fuzzer break through complex checks. For example:

```
if x > 5 && y < 6 && z > 9 {
  // coverage feedback 1 set here
  do_stuff();
}
```

becomes equivalent to this:

```
if x > 5 {
  // coverage feedback 1 set here
  if y < 6 {
    // coverage feedback 2 set here
    if z > 9 {
      // coverage feedback 3 set here
      do_stuff();
    }
  }
}
```


This link shows an example in godbolt (notice how with this flag there are 3 coverage feedback entries in the generated assembly): [example](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:rust,selection:(endColumn:4,endLineNumber:15,positionColumn:4,positionLineNumber:15,selectionStartColumn:4,selectionStartLineNumber:15,startColumn:4,startLineNumber:15),source:'//+Type+your+code+here,+or+load+an+example.%0A%0A//+As+of+Rust+1.75,+small+functions+are+automatically%0A//+marked+as+%60%23%5Binline%5D%60+so+they+will+not+show+up+in%0A//+the+output+when+compiling+with+optimisations.+Use%0A//+%60%23%5Bno_mangle%5D%60+or+%60%23%5Binline(never)%5D%60+to+work+around%0A//+this+issue.%0A//+See+https://github.com/compiler-explorer/compiler-explorer/issues/5939%0A%23%5Bno_mangle%5D%0Apub+fn+square(x:+i32,+y:+i32,+z:+i32)+-%3E+i32+%7B%0A++if+x+%3E+5+%26%26+y+%3C+4+%26%26+z+%3E+9+%7B%0A++++18%0A++%7D+else+%7B%0A++++12%0A++%7D%0A%7D%0A%0A//+If+you+use+%60main()%60,+declare+it+as+%60pub%60+to+see+it+in+the+output:%0A//+pub+fn+main()+%7B+...+%7D%0A'),l:'5',n:'1',o:'Rust+source+%231',t:'0')),k:32.342454394693206,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:r1800,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:2,lang:rust,libs:!(),options:'-C+opt-level%3D2+-Cpasses%3Dsancov-module+-Cllvm-args%3D-sanitizer-coverage-level%3D4+-Cllvm-args%3D-sanitizer-coverage-inline-8bit-counters+-Cllvm-args%3D-sanitizer-coverage-pc-table+',overrides:!(),selection:(endColumn:35,endLineNumber:19,positionColumn:35,positionLineNumber:19,selectionStartColumn:35,selectionStartLineNumber:19,startColumn:35,startLineNumber:19),source:1),l:'5',n:'0',o:'+rustc+1.80.0+(Editor+%231)',t:'0')),k:34.32421227197347,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:r1800,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:rust,libs:!(),options:'-C+opt-level%3D2+-Cpasses%3Dsancov-module+-Cllvm-args%3D-sanitizer-coverage-level%3D4+-Cllvm-args%3D-sanitizer-coverage-inline-8bit-counters+-Cllvm-args%3D-sanitizer-coverage-pc-table+-Cllvm-args%3D-simplifycfg-branch-fold-threshold%3D0',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+rustc+1.80.0+(Editor+%231)',t:'0')),k:33.33333333333333,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)

Hope this helps!