### PR TITLE
Disable lto and explicit profile

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -167,6 +167,17 @@ pub struct BuildOptions {
     pub disable_branch_folding: Option<bool>,
 }
 
+impl BuildOptions {
+    pub fn profile_name(&self) -> &str {
+        // we default to release mode unless debug mode is explicitly requested
+        if !self.dev {
+            "release"
+        } else {
+            "dev"
+        }
+    }
+}
+
 impl stdfmt::Display for BuildOptions {
     fn fmt(&self, f: &mut stdfmt::Formatter) -> stdfmt::Result {
         if self.dev {

--- a/src/project.rs
+++ b/src/project.rs
@@ -747,10 +747,10 @@ impl FuzzProject {
     ) -> Result<(Command, tempfile::TempDir)> {
         let bin_path = {
             // See https://doc.rust-lang.org/cargo/guide/build-cache.html for the mapping.
-            let profile_subdir = if coverage.build.profile_name() == "dev" {
-                "debug"
-            } else {
-                "release"
+            let profile_subdir = match coverage.build.profile_name() {
+                "dev" | "test" => "debug",
+                "release" | "bench" => "release",
+                other => other,
             };
 
             let target_dir = self

--- a/src/project.rs
+++ b/src/project.rs
@@ -142,7 +142,15 @@ impl FuzzProject {
             .arg(&build.triple);
         // we default to release mode unless debug mode is explicitly requested
         if !build.dev {
-            cmd.args(["--release", "--config", "profile.release.debug=true"]);
+            cmd.args([
+                "--release",
+                "--config",
+                "profile.release.debug=true",
+                "--config",
+                "profile.release.lto=false",
+            ]);
+        } else {
+            cmd.args(["--config", "profile.dev.lto=false"]);
         }
         if build.verbose {
             cmd.arg("--verbose");


### PR DESCRIPTION
Fixes #384.

I included both the disable LTO bit and the capability to support custom profiles. I'm happy to drop either one.

I'm concerned about how custom profiles will interact with these uses of `build.release` and `build.dev`:
https://github.com/rust-fuzz/cargo-fuzz/blob/a608970259c3b0d575e70b0748c1c4cf79081031/src/project.rs#L233-L235
and
https://github.com/rust-fuzz/cargo-fuzz/blob/a608970259c3b0d575e70b0748c1c4cf79081031/src/project.rs#L241-L251

I'm unclear how to determine the right condition for a custom profile -- might be a reason to drop that bit.