### PR TITLE
Add new build option to support Windows DLLs

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -279,6 +279,7 @@ mod test {
             no_cfg_fuzzing: false,
             no_trace_compares: false,
             disable_branch_folding: None,
+            no_include_main_msvc: false,
         };
 
         let opts = vec![

--- a/src/options.rs
+++ b/src/options.rs
@@ -165,6 +165,20 @@ pub struct BuildOptions {
     /// and the fuzzer can store an input to the corpus at each condition that it passes;
     /// giving it a better chance of producing an input that reaches `res = 2;`.
     pub disable_branch_folding: Option<bool>,
+
+    #[arg(long)]
+    /// Disable the inclusion of the `/include:main` MSVC linker argument
+    ///
+    /// The purpose of `/include:main` is to force the MSVC linker to include an
+    /// external reference to the symbol `main`, such that fuzzing targets built
+    /// on Windows are able to find LibFuzzer's `main` function.
+    ///
+    /// In certain corner cases, users may prefer to *not* build with this
+    /// argument. One such example: if a user is intending to build and fuzz a
+    /// Windows DLL, they would likely choose to enable this flag, to prevent
+    /// the DLL from having an extern `main` reference added to it. (DLLs/shared
+    /// libraries should not have any reference to `main`.)
+    pub no_include_main_msvc: bool,
 }
 
 impl stdfmt::Display for BuildOptions {

--- a/src/project.rs
+++ b/src/project.rs
@@ -248,8 +248,8 @@ impl FuzzProject {
 
             // NOTE: On Windows, if the user's fuzzing targets have a dependency
             // on a local Rust DLL (with `crate-type` containing `["cdylib"]),
-            // the MSVC Linker will be unable to resolve the `main` symbol when
-            // linking the DLL. It will fail with this error:
+            // the MSVC Linker may be unable to resolve the `main` symbol when
+            // linking the DLL. It may fail with this error:
             //
             //     LINK : error LNK2001: unresolved external symbol main
             //     C:\....\depedency.dll : fatal error LNK1120: 1 unresolved externals

--- a/src/project.rs
+++ b/src/project.rs
@@ -17,7 +17,7 @@ const DEFAULT_FUZZ_DIR: &str = "fuzz";
 
 /// The name of the environment variable that is exposed to indicate a
 /// cargo-fuzz build is occurring.
-const BUILD_ENV_CARGO_FUZZ: &str = "CARGO_FUZZ";
+const BUILD_ENV_FLAG: &str = "CARGO_FUZZ";
 
 /// The name of the environment variable that exposes the cargo fuzz manifest
 /// path during builds.
@@ -358,24 +358,23 @@ impl FuzzProject {
                   _build: &options::BuildOptions,
                   _fuzz_target: Option<&str>
     ) -> Result<()> {
-        // expose a boolean-like environment variable to allow the detection of
-        // cargo-fuzz
-        env::set_var(BUILD_ENV_CARGO_FUZZ, "1");
+        // expose a flag environment variable to allow the detection of cargo-fuzz
+        env::set_var(BUILD_ENV_FLAG, "1");
 
-        // expose the path to the cargo-fuzz manifest:
+        // expose the path to the cargo-fuzz manifest
         let manifest_path = self.manifest_path();
         env::set_var(BUILD_ENV_MANIFEST_DIR, manifest_path.as_os_str());
 
         Ok(())
     }
     
-    // Helper function for `exe_build()` used to un-expose cargo-fuzz
+    // Helper function for `exec_build()` used to un-expose cargo-fuzz
     // information that was previously exposed in environment variables during
     // `build_env_expose()`.
     //
     // This is called directly after the `cargo build ...` command is executed.
     fn build_env_unexpose(&self) -> Result<()> {
-        env::remove_var(BUILD_ENV_CARGO_FUZZ);
+        env::remove_var(BUILD_ENV_FLAG);
         env::remove_var(BUILD_ENV_MANIFEST_DIR);
         Ok(())
     }

--- a/src/project.rs
+++ b/src/project.rs
@@ -342,17 +342,18 @@ impl FuzzProject {
             Ok(None)
         }
     }
-    
+
     // Helper function for `exec_build()` used to expose cargo-fuzz information
     // via environment variables. Such environment variables can be used by fuzz
     // target dependencies' build scripts to detect whether or not cargo-fuzz is
     // responsible for the build.
     //
     // This is called directly before the `cargo build ...` command is executed.
-    fn build_env_expose(&self,
-                  _mode: options::BuildMode,
-                  _build: &options::BuildOptions,
-                  _fuzz_target: Option<&str>
+    fn build_env_expose(
+        &self,
+        _mode: options::BuildMode,
+        _build: &options::BuildOptions,
+        _fuzz_target: Option<&str>,
     ) -> Result<()> {
         // expose a flag environment variable to allow the detection of cargo-fuzz
         env::set_var(BUILD_ENV_FLAG, "1");
@@ -363,7 +364,7 @@ impl FuzzProject {
 
         Ok(())
     }
-    
+
     // Helper function for `exec_build()` used to un-expose cargo-fuzz
     // information that was previously exposed in environment variables during
     // `build_env_expose()`.
@@ -396,12 +397,11 @@ impl FuzzProject {
         if let Some(target_dir) = self.target_dir(&build)? {
             cmd.arg("--target-dir").arg(target_dir);
         }
-        
+
         // expose build information via environment variables, before executing
         // the build command
-        self.build_env_expose(mode, build, fuzz_target).expect(
-            "Failed to set cargo-fuzz build environment variables."
-        );
+        self.build_env_expose(mode, build, fuzz_target)
+            .expect("Failed to set cargo-fuzz build environment variables.");
 
         let status = cmd
             .status()
@@ -409,11 +409,10 @@ impl FuzzProject {
         if !status.success() {
             bail!("failed to build fuzz script: {:?}", cmd);
         }
-        
+
         // un-expose build information, after the command has finished
-        self.build_env_unexpose().expect(
-            "Failed to un-set cargo-fuzz build environment variables."
-        );
+        self.build_env_unexpose()
+            .expect("Failed to un-set cargo-fuzz build environment variables.");
 
         Ok(())
     }

--- a/src/project.rs
+++ b/src/project.rs
@@ -247,8 +247,8 @@ impl FuzzProject {
             // the DLL to compile with an external reference to `main`.
             // DLLs/shared libraries are designed to be built as a separate
             // object file, intentionally left *without* knowledge of the entry
-            // point. So, by forcing a DLL to include `main` will cause linking
-            // to fail. Using `--no-include-main-msvc` will allow the DLL to be
+            // point. So, forcing a DLL to include `main` will cause linking to
+            // fail. Using `--no-include-main-msvc` will allow the DLL to be
             // built without issue.
             rustflags.push_str(" -Clink-arg=/include:main");
         }


### PR DESCRIPTION
Hi - this PR implements a new build argument: `--no-include-main-msvc` - in order to help enable support for building and fuzzing Windows DLLs.

I recently ran into an issue when attempting to fuzz a Windows-only DLL (#386) where the `/include:main` linker argument that is added during `FuzzProject::cargo()` for MSVC-based builds gave the DLL a `main` symbol it could not resolve, which caused linking to fail:

```
LINK : error LNK2001: unresolved external symbol main
C:\....\depedency.dll : fatal error LNK1120: 1 unresolved externals
```

The DLL is, by nature, completely separate from the fuzzing targets in my cargo-fuzz repository, but I still wanted it to be a dependency listed in `fuzz/Cargo.toml`, so that it would be built and instrumented in the exact same way as the fuzzing target binaries. I found that by controlling whether or not `/include:main` is added to the `cargo build` arguments executed by cargo-fuzz, I was able to set up a "dummy" fuzzing target that provides its *own* main function:

```toml
# fuzz/Cargo.toml
# ...
[dependencies]
# the DLL is optional; only to be built with a specific feature
my_dll = { path = "..", optional = true }
# ...
[features]
build_dll = ["dep:my_dll"]
# ...
[[bin]]
name = "dummy_target_build_dll"
path = "fuzz_targets/dummy_target_build_dll.rs"
required-features = ["build_dll"]
test = false
doc = false
bench = false
# ... other binaries ...
```

```rust
// dummy_target_build_dll.rs
fn main()
{
    println!("DLL build complete! Now, copy the DLL to your desired location, `
              and use `cargo fuzz run` to run your other fuzzing targets.");
    // ... do other work, such as copying the DLL into the desired location ...
}
```

Then, by executing `cargo fuzz run --no-include-main-msvc --features=build_dll dummy_target`, the DLL would be built successfully. I could then proceed to run all other fuzzing targets, which would load in the instrumented DLL and fuzz it.

**TL;DR**: This solution allows Windows DLLs to be instrumented & fuzzed, but only if manual control over `/include:main` is allowed (hence, `--no-include-main-msvc`). This resolves #386.