### PR TITLE
Add aliases for subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -112,25 +112,28 @@ enum Command {
     #[command(
         help_template(LONG_ABOUT_TEMPLATE),
         before_help(BUILD_BEFORE_HELP),
-        after_help(BUILD_AFTER_HELP)
+        after_help(BUILD_AFTER_HELP),
+        visible_alias("b")
     )]
     /// Build fuzz targets
     Build(options::Build),
 
-    #[command(help_template(LONG_ABOUT_TEMPLATE))]
+    #[command(help_template(LONG_ABOUT_TEMPLATE), visible_alias("c"))]
     /// Type-check the fuzz targets
     Check(options::Check),
 
     /// Print the `std::fmt::Debug` output for an input
     Fmt(options::Fmt),
 
+    #[command(visible_alias("ls"))]
     /// List all the existing fuzz targets
     List(options::List),
 
     #[command(
         help_template(LONG_ABOUT_TEMPLATE),
         before_help(RUN_BEFORE_HELP),
-        after_help(RUN_AFTER_HELP)
+        after_help(RUN_AFTER_HELP),
+        visible_alias("r")
     )]
     /// Run a fuzz target
     Run(options::Run),
@@ -141,6 +144,7 @@ enum Command {
     /// Minify a test case
     Tmin(options::Tmin),
 
+    #[command(visible_alias("cov"))]
     /// Run program on the generated corpus and generate coverage information
     Coverage(options::Coverage),
 }


### PR DESCRIPTION
This PR adds several "cargo-like" aliases for common subcommands, presumably:
- `b` for `build`
- `r` for `run`
- `c` for `check`
- `ls` for `list`
- `cov` for `coverage`

The help message after the added changes:
```
A `cargo` subcommand for fuzzing with `libFuzzer`! Easy to use!

Usage: cargo-fuzz <COMMAND>

Commands:
  init      Initialize the fuzz directory
  add       Add a new fuzz target
  build     Build fuzz targets [aliases: b]
  check     Type-check the fuzz targets [aliases: c]
  fmt       Print the `std::fmt::Debug` output for an input
  list      List all the existing fuzz targets [aliases: ls]
  run       Run a fuzz target [aliases: r]
  cmin      Minify a corpus
  tmin      Minify a test case
  coverage  Run program on the generated corpus and generate coverage information [aliases: cov]
  help      Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help information
  -V, --version  Print version information
```

So it means that one, for example, can write
````
cargo fuzz b <target>
````
instead of
```
cargo fuzz build <target>
```