### PR TITLE
Revert note about nightly rust in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ $ cargo install cargo-fuzz
 ```
 
 Note: `libFuzzer` needs LLVM sanitizer support, so this only works on x86-64 and Aarch64,
-and only on Unix-like operating systems (not Windows). You'll also need a C++ compiler with C++11 support.
+and only on Unix-like operating systems (not Windows). This also needs a nightly compiler since it uses some
+ unstable command-line flags. You'll also need a C++ compiler with C++11 support.
 
 ## Usage
 


### PR DESCRIPTION
#359 removed the note about nightly rust.
But `--sanitizer address` which is enabled by default requires `-Zsanitizer=address` which is a nightly feature.
So I think the note is necessary until merging https://github.com/rust-lang/rust/pull/123617.
