### PR TITLE
Generate less debug info by default.

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -145,7 +145,7 @@ impl FuzzProject {
             cmd.args([
                 "--release",
                 "--config",
-                "profile.release.debug=true",
+                "profile.release.debug=\"line-tables-only\"",
                 "--config",
                 "profile.release.strip=false",
             ]);


### PR DESCRIPTION
`cargo fuzz build` causes `-Cdebuginfo=2` to be used. This produces maximal debuginfo: filenames and line numbers, and also type/variable info. This adds to compile time.

This commit changes it so that `-Cdebuginfo=line-tables-only` is used instead. I think filenames/line numbers should be enough for fuzzing. On one project I know of this reduced full build times on a Mac from ~2m12s to ~1m44s, and rebuilds (after changing a single file) from ~1m18s to ~1m02s.