### PR TITLE
Add `--codegen-units` flag.

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -116,6 +116,12 @@ pub struct BuildOptions {
     #[arg(skip = false)]
     pub coverage: bool,
 
+    /// Number of codegen units to use. Default is 1 in non-dev builds. 16 may
+    /// be a good choice if you want faster fuzz builds at the cost of somewhat
+    /// slower fuzz runs.
+    #[arg(long)]
+    pub codegen_units: Option<usize>,
+
     /// Dead code is stripped by default.
     /// This flag allows you to opt out and always include dead code.
     /// Please note, this could trigger unexpected behavior or even ICEs in the compiler.
@@ -294,6 +300,7 @@ mod test {
             unstable_flags: Vec::new(),
             target_dir: None,
             coverage: false,
+            codegen_units: None,
             strip_dead_code: None,
             no_cfg_fuzzing: false,
             no_trace_compares: false,

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -944,6 +944,7 @@ fn build_with_all_llvm_features() {
         .arg("--trace-div")
         .arg("--trace-gep")
         .arg("--disable-branch-folding")
+        .arg("--codegen-units=10")
         .assert()
         .success();
 


### PR DESCRIPTION
The default in non-dev builds is 1, which gives better fuzzing performance at a very high build-time cost, because it eliminates all parallelism from the LLVM backend. There are times, e.g. short "smoke test" fuzzing runs, where a faster build with slower fuzzing is a good trade-off, and this new flag makes that easier to do.