### PR TITLE
Revert part of #415.

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -142,7 +142,13 @@ impl FuzzProject {
             .arg(&build.triple);
         // we default to release mode unless debug mode is explicitly requested
         if !build.dev {
-            cmd.args(["--release"]);
+            // Note: setting `debug` doesn't only affect `-Cdebuginfo`. It also
+            // affects how cargo uses `-Cstrip` and `-Csplit-debuginfo`.
+            cmd.args([
+                "--release",
+                "--config",
+                "profile.release.debug=\"line-tables-only\"",
+            ]);
         }
         if build.verbose {
             cmd.arg("--verbose");
@@ -288,9 +294,6 @@ impl FuzzProject {
             if build.codegen_units.is_none() {
                 rustflags.push_str(" -Ccodegen-units=1");
             }
-
-            // Line numbers are enough and full debuginfo is slow.
-            rustflags.push_str(" -Cdebuginfo=line-tables-only");
         }
 
         // If the user specified RUSTFLAGS, append that to the RUSTFLAGS


### PR DESCRIPTION
The second commit in #415 replaced the use of
`--config profile.release.debug="line-tables-only"` with `-Cdebuginfo=line-tables-only`. I mistakenly thought these were equivalent, but the former can also affect Cargo's use/non-use of `-Csplit-debuginfo=unpacked` and `-Cstrip=debuginfo`.

As a result, cargo is now being run with the nonsensical combination of `-Cdebuginfo=line-tables-only` and `-Cstrip=debuginfo`. I.e. "please give me some debuginfo" and "please strip all debuginfo".

This commit reverts the relevant part of that commit and adds a test that would have caught the problem. Sorry for the mix-up!