### PR TITLE
Fix cargo clippy warnings and errors

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -353,7 +353,7 @@ impl FuzzProject {
         // Use the user-provided target directory, if provided. Otherwise if building for coverage,
         // use the coverage directory
         if let Some(target_dir) = build.target_dir.as_ref() {
-            return Ok(Some(PathBuf::from(target_dir)));
+            Ok(Some(PathBuf::from(target_dir)))
         } else if build.coverage {
             // To ensure that fuzzing and coverage-output generation can run in parallel, we
             // produce a separate binary for the coverage command.
@@ -387,7 +387,7 @@ impl FuzzProject {
             cmd.arg("--bins");
         }
 
-        if let Some(target_dir) = self.target_dir(&build)? {
+        if let Some(target_dir) = self.target_dir(build)? {
             cmd.arg("--target-dir").arg(target_dir);
         }
 
@@ -756,7 +756,7 @@ impl FuzzProject {
         for corpus in corpora.iter() {
             // _tmp_dir is deleted when it goes of of scope.
             let (mut cmd, _tmp_dir) =
-                self.create_coverage_cmd(coverage, &coverage_out_raw_dir, &corpus.as_path())?;
+                self.create_coverage_cmd(coverage, &coverage_out_raw_dir, corpus.as_path())?;
             eprintln!("Generating coverage data for corpus {:?}", corpus);
             let status = cmd
                 .status()

--- a/src/rustc_version.rs
+++ b/src/rustc_version.rs
@@ -22,7 +22,7 @@ fn rust_version_string() -> anyhow::Result<String> {
     String::from_utf8(raw_output).context("`rustc --version` returned non-text output somehow")
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct RustVersion {
     pub major: u32,
     pub minor: u32,
@@ -36,6 +36,12 @@ impl Ord for RustVersion {
             Ordering::Equal => self.minor.cmp(&other.minor),
             other => other,
         }
+    }
+}
+
+impl PartialOrd for RustVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
I noticed these clippy errors when building:

```
% cargo +stable --version
cargo 1.90.0 (840b83a10 2025-07-30)
% cargo +stable clippy
    Checking cargo-fuzz v0.13.1 (/Users/patrick/git/cargo-fuzz)
warning: unneeded `return` statement
   --> src/project.rs:356:13
    |
356 |             return Ok(Some(PathBuf::from(target_dir)));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
    = note: `#[warn(clippy::needless_return)]` on by default
help: remove `return`
    |
356 -             return Ok(Some(PathBuf::from(target_dir)));
356 +             Ok(Some(PathBuf::from(target_dir)))
    |

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/project.rs:390:51
    |
390 |         if let Some(target_dir) = self.target_dir(&build)? {
    |                                                   ^^^^^^ help: change this to: `build`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `#[warn(clippy::needless_borrow)]` on by default

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/project.rs:759:75
    |
759 |                 self.create_coverage_cmd(coverage, &coverage_out_raw_dir, &corpus.as_path())?;
    |                                                                           ^^^^^^^^^^^^^^^^^ help: change this to: `corpus.as_path()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: you are implementing `Ord` explicitly but have derived `PartialOrd`
  --> src/rustc_version.rs:33:1
   |
33 | / impl Ord for RustVersion {
34 | |     fn cmp(&self, other: &Self) -> Ordering {
35 | |         match self.major.cmp(&other.major) {
36 | |             Ordering::Equal => self.minor.cmp(&other.minor),
...  |
40 | | }
   | |_^
   |
note: `PartialOrd` implemented here
  --> src/rustc_version.rs:25:45
   |
25 | #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd)]
   |                                             ^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_ord_xor_partial_ord
   = note: `#[deny(clippy::derive_ord_xor_partial_ord)]` on by default

warning: `cargo-fuzz` (bin "cargo-fuzz") generated 3 warnings
error: could not compile `cargo-fuzz` (bin "cargo-fuzz") due to 1 previous error; 3 warnings emitted
```