### PR TITLE
Cargo workspace support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,6 @@ dependencies = [
  "rayon",
  "rustc_version",
  "tempfile",
- "toml",
 ]
 
 [[package]]
@@ -613,15 +612,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,45 +666,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow",
-]
-
-[[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "unicode-ident"
@@ -809,12 +760,6 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "winnow"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ anyhow = "1.0.66"
 current_platform = "0.2.0"
 clap = { version = "4.4.0", features = ["derive", "deprecated"] }
 tempfile = "3.4.0"
-toml = "1"
 rustc_version = "0.4.0"
 cargo_metadata = "0.23"
 rayon = "1.11"

--- a/src/options/add.rs
+++ b/src/options/add.rs
@@ -14,7 +14,7 @@ pub struct Add {
 
 impl RunCommand for Add {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
+        let project = FuzzProject::new(self.fuzz_dir_wrapper.get_manifest_path())?;
         let manifest = Manifest::parse()?;
         project.add_target(self, &manifest)
     }

--- a/src/options/build.rs
+++ b/src/options/build.rs
@@ -1,5 +1,5 @@
 use crate::{
-    options::{BuildMode, BuildOptions, FuzzDirWrapper},
+    options::{BuildMode, BuildOptions},
     project::FuzzProject,
     RunCommand,
 };
@@ -11,16 +11,13 @@ pub struct Build {
     #[command(flatten)]
     pub build: BuildOptions,
 
-    #[command(flatten)]
-    pub fuzz_dir_wrapper: FuzzDirWrapper,
-
     /// Name of the fuzz target to build, or build all targets if not supplied
     pub target: Option<String>,
 }
 
 impl RunCommand for Build {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
+        let project = FuzzProject::new(self.build.fuzz_dir_wrapper.get_manifest_path())?;
         project.exec_build(BuildMode::Build, &self.build, self.target.as_deref())
     }
 }

--- a/src/options/check.rs
+++ b/src/options/check.rs
@@ -1,5 +1,5 @@
 use crate::{
-    options::{BuildMode, BuildOptions, FuzzDirWrapper},
+    options::{BuildMode, BuildOptions},
     project::FuzzProject,
     RunCommand,
 };
@@ -11,16 +11,13 @@ pub struct Check {
     #[command(flatten)]
     pub build: BuildOptions,
 
-    #[command(flatten)]
-    pub fuzz_dir_wrapper: FuzzDirWrapper,
-
     /// Name of the fuzz target to check, or check all targets if not supplied
     pub target: Option<String>,
 }
 
 impl RunCommand for Check {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
+        let project = FuzzProject::new(self.build.fuzz_dir_wrapper.get_manifest_path())?;
         project.exec_build(BuildMode::Check, &self.build, self.target.as_deref())
     }
 }

--- a/src/options/cmin.rs
+++ b/src/options/cmin.rs
@@ -1,8 +1,4 @@
-use crate::{
-    options::{BuildOptions, FuzzDirWrapper},
-    project::FuzzProject,
-    RunCommand,
-};
+use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
 use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
@@ -11,9 +7,6 @@ use std::path::PathBuf;
 pub struct Cmin {
     #[command(flatten)]
     pub build: BuildOptions,
-
-    #[command(flatten)]
-    pub fuzz_dir_wrapper: FuzzDirWrapper,
 
     /// Name of the fuzz target
     pub target: String,
@@ -29,7 +22,7 @@ pub struct Cmin {
 
 impl RunCommand for Cmin {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
+        let project = FuzzProject::new(self.build.fuzz_dir_wrapper.get_manifest_path())?;
         project.exec_cmin(self)
     }
 }

--- a/src/options/coverage.rs
+++ b/src/options/coverage.rs
@@ -1,10 +1,6 @@
 use std::path::PathBuf;
 
-use crate::{
-    options::{BuildOptions, FuzzDirWrapper},
-    project::FuzzProject,
-    RunCommand,
-};
+use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
 use anyhow::{bail, Result};
 use clap::Parser;
 
@@ -12,9 +8,6 @@ use clap::Parser;
 pub struct Coverage {
     #[command(flatten)]
     pub build: BuildOptions,
-
-    #[command(flatten)]
-    pub fuzz_dir_wrapper: FuzzDirWrapper,
 
     /// Sets the path to the LLVM bin directory. By default, it will use the one installed with rustc
     #[arg(long)]
@@ -48,7 +41,7 @@ impl RunCommand for Coverage {
                 see https://github.com/rust-lang/wg-cargo-std-aware/issues/63"
             );
         }
-        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
+        let project = FuzzProject::new(self.build.fuzz_dir_wrapper.get_manifest_path())?;
         self.build.coverage = true;
         project.exec_coverage(self)
     }

--- a/src/options/fmt.rs
+++ b/src/options/fmt.rs
@@ -1,8 +1,4 @@
-use crate::{
-    options::{BuildOptions, FuzzDirWrapper},
-    project::FuzzProject,
-    RunCommand,
-};
+use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
 use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
@@ -11,9 +7,6 @@ use std::path::PathBuf;
 pub struct Fmt {
     #[command(flatten)]
     pub build: BuildOptions,
-
-    #[command(flatten)]
-    pub fuzz_dir_wrapper: FuzzDirWrapper,
 
     /// Name of fuzz target
     pub target: String,
@@ -24,7 +17,7 @@ pub struct Fmt {
 
 impl RunCommand for Fmt {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
+        let project = FuzzProject::new(self.build.fuzz_dir_wrapper.get_manifest_path())?;
         project.debug_fmt_input(self)
     }
 }

--- a/src/options/list.rs
+++ b/src/options/list.rs
@@ -10,7 +10,7 @@ pub struct List {
 
 impl RunCommand for List {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
+        let project = FuzzProject::new(self.fuzz_dir_wrapper.get_manifest_path())?;
         project.list_targets()
     }
 }

--- a/src/options/run.rs
+++ b/src/options/run.rs
@@ -1,8 +1,4 @@
-use crate::{
-    options::{BuildOptions, FuzzDirWrapper},
-    project::FuzzProject,
-    RunCommand,
-};
+use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
 use anyhow::Result;
 use clap::Parser;
 
@@ -16,9 +12,6 @@ pub struct Run {
 
     /// Custom corpus directories or artifact files.
     pub corpus: Vec<String>,
-
-    #[command(flatten)]
-    pub fuzz_dir_wrapper: FuzzDirWrapper,
 
     #[arg(
         short,
@@ -36,7 +29,7 @@ pub struct Run {
 
 impl RunCommand for Run {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
+        let project = FuzzProject::new(self.build.fuzz_dir_wrapper.get_manifest_path())?;
         project.exec_fuzz(self)
     }
 }

--- a/src/options/tmin.rs
+++ b/src/options/tmin.rs
@@ -1,8 +1,4 @@
-use crate::{
-    options::{BuildOptions, FuzzDirWrapper},
-    project::FuzzProject,
-    RunCommand,
-};
+use crate::{options::BuildOptions, project::FuzzProject, RunCommand};
 use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
@@ -11,9 +7,6 @@ use std::path::PathBuf;
 pub struct Tmin {
     #[command(flatten)]
     pub build: BuildOptions,
-
-    #[command(flatten)]
-    pub fuzz_dir_wrapper: FuzzDirWrapper,
 
     /// Name of the fuzz target
     pub target: String,
@@ -38,7 +31,7 @@ pub struct Tmin {
 
 impl RunCommand for Tmin {
     fn run_command(&mut self) -> Result<()> {
-        let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.to_owned())?;
+        let project = FuzzProject::new(self.build.fuzz_dir_wrapper.get_manifest_path())?;
         project.exec_tmin(self)
     }
 }

--- a/tests/tests/project.rs
+++ b/tests/tests/project.rs
@@ -170,9 +170,15 @@ impl ProjectBuilder {
         )
     }
 
-    pub fn default_src_lib(&mut self) -> &mut Self {
+    pub fn default_src_lib(&mut self, prefix: Option<PathBuf>) -> &mut Self {
+        let path = Path::new("src").join("lib.rs");
+        let path = if let Some(prefix) = prefix {
+            prefix.join(path)
+        } else {
+            path
+        };
         self.file(
-            Path::new("src").join("lib.rs"),
+            path,
             r#"
                 pub fn pass_fuzzing(data: &[u8]) {
                     let _ = data;
@@ -192,7 +198,7 @@ impl ProjectBuilder {
             self.default_cargo_toml();
         }
         if !self.saw_main_or_lib {
-            self.default_src_lib();
+            self.default_src_lib(None);
         }
         Project {
             fuzz_dir: self.project.fuzz_dir.clone(),


### PR DESCRIPTION
Currently, `cargo-fuzz` implements manual parser for `Cargo.toml`,
which means that only a very specific project structure is supported.
Namely, this only supports either one of:
1. Explicitly specified project directory
2. A mono-project in `"<workspace root>"/fuzz`
... where "<workspace root>" is found arbitrairly.

My biggest problem with this, is that if i want to have
a workspace-style layout for `fuzz` project,
i.e. `/fuzz/Cargo.toml` isn't a project,
but `/fuzz/foo/Cargo.toml` and `/fuzz/bar/Cargo.toml` are,
current cargo-fuzz simply doesn't support this. 

The overall solution is to stop parsing `Cargo.toml` manually,
and rely on `cargo metadata`, via existing `cargo-metadata` dep.

I've tried very hard to preserve existing functionality,
but i'm not sure how good the test coverage is.

Now, let's mention fuzz artifact dirs location (`corpus`, etc).
Currently, they will still all be located in `<workspace root>`,
but with a caveat: if the `<workspace root>/fuzz`
is part of `<workspace root>` project,
then they will no longer be stored in `fuzz` subdirectory.

Additonally, i'm wondering if this is the right default anyway,
should they be stored in, `<fuzz project root>` of each target?
Incindentally, this would restore the previous default.

Thoughts?

Fixes https://github.com/rust-fuzz/cargo-fuzz/issues/430.