### PR TITLE
Perf/cmin parallel processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
  "assert_cmd",
  "cargo_metadata",
  "clap",
+ "crossbeam",
  "current_platform",
  "num_cpus",
  "predicates",
@@ -154,6 +155,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +191,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rustc_version = "0.4.0"
 cargo_metadata = "0.18.1"
 rayon = "1.11"
 num_cpus = "1.17"
+crossbeam = "0.8.4"
 
 [dev-dependencies]
 assert_cmd = "2.0.7"

--- a/src/options.rs
+++ b/src/options.rs
@@ -10,8 +10,8 @@ mod run;
 mod tmin;
 
 pub use self::{
-    add::Add, build::Build, check::Check, cmin::Cmin, coverage::Coverage, fmt::Fmt, init::Init,
-    list::List, run::Run, tmin::Tmin,
+    add::Add, build::Build, check::Check, cmin::Cmin, cmin::CminStrategy, coverage::Coverage,
+    fmt::Fmt, init::Init, list::List, run::Run, tmin::Tmin,
 };
 
 use anyhow::{bail, Error, Result};

--- a/src/options/cmin.rs
+++ b/src/options/cmin.rs
@@ -22,6 +22,15 @@ pub struct Cmin {
     /// The corpus directory to minify into
     pub corpus: Option<PathBuf>,
 
+    #[arg(
+        short,
+        long,
+        default_value_t = u16::try_from(num_cpus::get().max(1)).unwrap_or(u16::MAX),
+        value_parser = clap::value_parser!(u16).range(1..)
+    )]
+    /// Number of parallel jobs (defaults to number of CPUs)
+    pub jobs: u16,
+
     #[arg(last(true))]
     /// Additional libFuzzer arguments passed through to the binary
     pub args: Vec<String>,

--- a/src/options/cmin.rs
+++ b/src/options/cmin.rs
@@ -4,7 +4,7 @@ use crate::{
     RunCommand,
 };
 use anyhow::Result;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, Parser)]
@@ -31,9 +31,20 @@ pub struct Cmin {
     /// Number of parallel jobs (defaults to number of CPUs)
     pub jobs: u16,
 
+    #[arg(long, value_enum, default_value_t = CminStrategy::Speed)]
+    /// Minimization strategy: `speed` finds a minset without global optimization,
+    /// while `size` produces the globally optimal smallest minset.
+    pub strategy: CminStrategy,
+
     #[arg(last(true))]
     /// Additional libFuzzer arguments passed through to the binary
     pub args: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum CminStrategy {
+    Speed,
+    Size,
 }
 
 impl RunCommand for Cmin {


### PR DESCRIPTION
Add a cmin strategy `speed` which batches corpora into N workers and merges workers in pairs until single, minimized corpora is produced. In my experiment, this is about 10x faster and results in about 35% more files. The minset is still correct, but we are not adding the `size` constraint that libfuzzer has (it will replace 2 files with 1 if it covers the same edges but is smaller).

Initially, I tried implementing this like `coverage` which can be run in parallel batches and aggregated at the very end. It offered some performance benefits but still had to execute about half the initial corpus serially. In order to benefit from more rounds of parallel batches and not incur too much re-execution overhead, I exploited the interrupt-recovery mechanism in libfuzzer's control file to merge batches pairwise. For example, if we merge batch A and batch B, we effectively cache the features and coverage info of A, requiring libfuzzer to only re-run B to minimize A and B. While this is only approximating the global optima wrt to size, sometimes the speed is worth it.

Because each round experiences reduction and we can cache half the inputs each round, we re-execute inputs far less than if we were not to use the caching and perform pairwise merging.

`size` strategy 
```
MERGE-OUTER: 2357 new files with 33046 new features added; 16554 new coverage edges
```

`speed` strategy
```
Merge worker 11: Merging "49" and "94"
MERGE-INNER: using the control file '/tmp/.tmp7No5Hf/49.control'
MERGE-INNER: 12551 total files; 9422 processed earlier; will process 3129 files now # Caching 
MERGE-OUTER: 2023 new files with 32403 new features added; 16547 new coverage edges
Final corpus: 3187 files
```