### PR TITLE
Enable memory sanitizer tests again

### DIFF
--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -437,85 +437,83 @@ fn run_without_sanitizer_with_crash() {
         .failure();
 }
 
-// TODO: these msan tests are crashing `rustc` in CI:
-// https://github.com/rust-fuzz/cargo-fuzz/issues/323
-//
-// #[test]
-// fn run_with_msan_no_crash() {
-//     let project = project("run_with_msan_no_crash")
-//         .with_fuzz()
-//         .fuzz_target(
-//             "msan_no_crash",
-//             r#"
-//                 #![no_main]
-//                 use libfuzzer_sys::fuzz_target;
-//
-//                 fuzz_target!(|data: &[u8]| {
-//                     // get data from fuzzer and print it
-//                     // to force a memory access that cannot be optimized out
-//                     if let Some(x) = data.get(0) {
-//                         dbg!(x);
-//                     }
-//                 });
-//             "#,
-//         )
-//         .build();
-//
-//     project
-//         .cargo_fuzz()
-//         .arg("run")
-//         .arg("--sanitizer=memory")
-//         .arg("msan_no_crash")
-//         .arg("--")
-//         .arg("-runs=1000")
-//         .assert()
-//         .stderr(predicate::str::contains("Done 1000 runs"))
-//         .success();
-// }
-//
-// #[test]
-// fn run_with_msan_with_crash() {
-//     let project = project("run_with_msan_with_crash")
-//         .with_fuzz()
-//         .fuzz_target(
-//             "msan_with_crash",
-//             r#"
-//                 #![no_main]
-//                 use libfuzzer_sys::fuzz_target;
-//
-//                 fuzz_target!(|data: &[u8]| {
-//                     let test_data: Vec<u8> = Vec::with_capacity(4);
-//                     let uninitialized_value = unsafe {test_data.get_unchecked(0)};
-//                     // prevent uninit read from being optimized out
-//                     println!("{}", uninitialized_value);
-//                 });
-//             "#,
-//         )
-//         .build();
-//
-//     project
-//         .cargo_fuzz()
-//         .arg("run")
-//         .arg("--sanitizer=memory")
-//         .arg("msan_with_crash")
-//         .arg("--")
-//         .arg("-runs=1000")
-//         .assert()
-//         .stderr(
-//             predicate::str::contains("MemorySanitizer: use-of-uninitialized-value")
-//                 .and(predicate::str::contains(
-//                     "Reproduce with:\n\
-//                 \n\
-//                 \tcargo fuzz run --sanitizer=memory msan_with_crash fuzz/artifacts/msan_with_crash/crash-",
-//                 ))
-//                 .and(predicate::str::contains(
-//                     "Minimize test case with:\n\
-//                 \n\
-//                 \tcargo fuzz tmin --sanitizer=memory msan_with_crash fuzz/artifacts/msan_with_crash/crash-",
-//                 )),
-//         )
-//         .failure();
-// }
+#[test]
+fn run_with_msan_no_crash() {
+    let project = project("run_with_msan_no_crash")
+        .with_fuzz()
+        .fuzz_target(
+            "msan_no_crash",
+            r#"
+                #![no_main]
+                use libfuzzer_sys::fuzz_target;
+                use std::hint::black_box;
+
+                fuzz_target!(|data: &[u8]| {
+                    if let Some(x) = data.get(0) {
+                        black_box(x);
+                    }
+                });
+            "#,
+        )
+        .build();
+
+    project
+        .cargo_fuzz()
+        .arg("run")
+        .arg("--sanitizer=memory")
+        .arg("msan_no_crash")
+        .arg("--")
+        .arg("-runs=1000")
+        .assert()
+        .stderr(predicate::str::contains("Done 1000 runs"))
+        .success();
+}
+
+#[test]
+fn run_with_msan_with_crash() {
+    let project = project("run_with_msan_with_crash")
+        .with_fuzz()
+        .fuzz_target(
+            "msan_with_crash",
+            r#"
+                #![no_main]
+                use libfuzzer_sys::fuzz_target;
+                use std::mem::MaybeUninit;
+
+                fuzz_target!(|data: &[u8]| {
+                    unsafe {
+                        let a = MaybeUninit::<[usize; 4]>::uninit();
+                        let a = a.assume_init();
+                        println!("{}", a[2]);
+                    }
+                });
+            "#,
+        )
+        .build();
+
+    project
+        .cargo_fuzz()
+        .arg("run")
+        .arg("--sanitizer=memory")
+        .arg("msan_with_crash")
+        .arg("--")
+        .arg("-runs=1000")
+        .assert()
+        .stderr(
+            predicate::str::contains("MemorySanitizer: use-of-uninitialized-value")
+                .and(predicate::str::contains(
+                    "Reproduce with:\n\
+                \n\
+                \tcargo fuzz run --sanitizer=memory msan_with_crash fuzz/artifacts/msan_with_crash/crash-",
+                ))
+                .and(predicate::str::contains(
+                    "Minimize test case with:\n\
+                \n\
+                \tcargo fuzz tmin --sanitizer=memory msan_with_crash fuzz/artifacts/msan_with_crash/crash-",
+                )),
+        )
+        .failure();
+}
 
 #[test]
 fn run_one_input() {


### PR DESCRIPTION
See also #323
It seems the test works on CI again

Reverts 7ad9e92dcce0530c47c1da2772d16523f4c21b0d and adjusts the test slightly using the current example from https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html#memorysanitizer because the previous `get_unchecked` usage failed with "unsafe precondition(s) violated" instead of actually causing a sanitizer error.