### PR TITLE
Update deploy workflow to include x86_64-unknown-linux-gnu target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,12 +50,17 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [macos-latest, ubuntu-22.04, ubuntu-latest]
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
           - os: macos-latest
             target: x86_64-apple-darwin
+
+          # Use oldest available Linux runner for maximum glibc compatibility
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Context: https://github.com/rust-fuzz/cargo-fuzz/issues/398#issuecomment-3813034867

Note: Ubuntu 22.04 uses glibc 2.35