### PR TITLE
Clarify stable support for --sanitizer none

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ $ cargo install cargo-fuzz
 ```
 
 Note: `libFuzzer` needs LLVM sanitizer support, so this only works on x86-64 and Aarch64,
-and only on Unix-like operating systems (not Windows). This also needs a nightly compiler since it uses some
- unstable command-line flags. You'll also need a C++ compiler with C++11 support.
+and only on Unix-like operating systems (not Windows). The default sanitizer-backed workflow
+also uses unstable command-line flags, so it still usually needs a nightly compiler. A reduced
+`--sanitizer none` mode can run on stable, but without sanitizer-based bug finding. You'll also
+need a C++ compiler with C++11 support.
 
 ## Usage
 
@@ -33,6 +35,25 @@ Create a new fuzzing target!
 ### `cargo fuzz run <target>`
 
 Run a fuzzing target and find bugs!
+
+### Stable Rust in reduced mode
+
+`cargo fuzz` normally relies on sanitizer support. The default `cargo fuzz run <target>` path
+enables AddressSanitizer and still requires nightly.
+
+If you need a reduced mode that works on stable, pass `--sanitizer none`:
+
+```sh
+$ cargo fuzz check --sanitizer none <target>
+$ cargo fuzz run --sanitizer none <target> -- -runs=1
+```
+
+This still gives you coverage-guided fuzzing and can catch crashes, panics, and similar failures,
+but it disables sanitizer-based findings such as ASan, LSan, MSan, and TSan.
+
+On stable, do not expect options that require Cargo or rustc `-Z` flags, such as the default
+AddressSanitizer flow, `--sanitizer address`, `--sanitizer memory`, `--build-std`, or
+`--careful`, to work.
 
 ### `cargo fuzz fmt <target> <input>`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,12 @@ libFuzzer options below), this will run indefinitely.
 
 By default fuzz targets are built with optimizations equivalent to
 `cargo build --release`, but with debug assertions and overflow checks enabled.
-Address Sanitizer is also enabled by default.";
+Address Sanitizer is also enabled by default.
+
+That default sanitizer-backed workflow still requires nightly. Reduced fuzzing
+without sanitizer checks is available with `--sanitizer none`, which can work
+on stable as long as you avoid other nightly-only options such as
+`--build-std`, `--careful`, or extra `-Z` flags.";
 
 const RUN_AFTER_HELP: &str = "\
 A full list of libFuzzer options can be found at
@@ -75,7 +80,12 @@ include:
 const BUILD_BEFORE_HELP: &str = "\
 By default fuzz targets are built with optimizations equivalent to
 `cargo build --release`, but with debug assertions and overflow checks enabled.
-Address Sanitizer is also enabled by default.";
+Address Sanitizer is also enabled by default.
+
+That default sanitizer-backed workflow still requires nightly. Reduced builds
+without sanitizer checks are available with `--sanitizer none`, which can work
+on stable as long as you avoid other nightly-only options such as
+`--build-std`, `--careful`, or extra `-Z` flags.";
 
 const BUILD_AFTER_HELP: &str = "\
 Sanitizers perform checks necessary for detecting bugs in unsafe code

--- a/src/options.rs
+++ b/src/options.rs
@@ -79,7 +79,8 @@ pub struct BuildOptions {
     #[arg(long)]
     pub features: Option<String>,
 
-    /// Use a specific sanitizer
+    /// Use a specific sanitizer. `none` disables sanitizer checks and can work
+    /// on stable as long as no other nightly-only options are enabled.
     #[arg(short, long, value_enum, default_value = "address")]
     pub sanitizer: Sanitizer,
 


### PR DESCRIPTION
The previous wording implied that cargo-fuzz always requires nightly, which is too broad now that reduced `--sanitizer none` mode works on stable. Updated the docs and CLI help text to clarify that cargo-fuzz can run on stable Rust in reduced `--sanitizer none` mode.

  - keep documenting nightly as required for the default sanitizer-backed workflow
  - explain that `--sanitizer none` can work on stable
  - note that stable reduced mode does not provide sanitizer-based findings
  - call out that nightly-only options such as `--build-std`, `--careful`, and extra `-Z` flags are still not expected to work on stable
  
related: #411